### PR TITLE
Add `propertynames` for `AquaCropField`

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -32,6 +32,14 @@ function Base.getproperty(b::AquaCropField, s::Symbol)
     end
 end
 
+function Base.propertynames(b::AquaCropField, private::Bool=false)
+    # TODO: private is currently ignored
+    return tuple(union(
+        fieldnames(AquaCropField),
+        keys(getfield(b, :outputs)),
+        keys(getfield(b, :gvars))
+    )...)
+end
 
 """
     dailyupdate!(cropfield::AquaCropField)

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -143,7 +143,7 @@ end
 end
 
 @testset "AquaCropField utility functions" begin
-    cropfield = AquaCropField(Dict(:foo => "bar"), Dict(), Dict())
+    cropfield = AquaCropField(Dict(:foo => "bar"), Dict(), Dict(), [AquaCrop.StartCropField()])
     @test propertynames(cropfield) isa Tuple
     @test all(x -> x isa Symbol, propertynames(cropfield))
 end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -130,3 +130,8 @@ end
     @test isequal(size(cropfield.dayout), (164, 89))
 end
 
+@testset "AquaCropField utility functions" begin
+    cropfield = AquaCropField(Dict(:foo => "bar"), Dict(), Dict())
+    @test propertynames(cropfield) isa Tuple
+    @test all(x -> x isa Symbol, propertynames(cropfield))
+end


### PR DESCRIPTION
Makes tab-completion in the REPL a little easier when working with an `AquaCropField`