### PR TITLE
add write to csv function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Gabriel Diaz <gabriel.diaz.iturry@gmail.com>"]
 version = "0.1.0-DEV"
 
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -89,6 +89,19 @@ the information for the evaluation dataframe `outputs[:evaldataout]`,
 and the logger information in `outputs[:logger]`.
 Note the output dataframes correspond to output files in a run of AquaCrop Fortran.
 
+You can write the output in csv file using the [`write_out_csv`](@ref) function
+```jldoctest basic_run_example
+io = IOBuffer() 
+
+write_out_csv(io, outputs[:seasonout]) # instead of io  you can use a filename like "example.csv"
+
+io
+
+# output
+IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=925, maxsize=Inf, ptr=926, mark=-1)
+```
+
+
 ### Using TOML files
 
 If you prefer to use TOML and CSV files for configuring the input, then 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,5 +30,5 @@ of the [Helmholtz Centre for Environmental Research - UFZ](https://www.ufz.de/) 
 the [German Centre for Integrative Biodiversity Research (iDiv) Halle-Jena-Leipzig](https://www.idiv.de/).
 Development was funded through the project [CAP4GI](https://cap4gi.de/en) by the 
 Federal Ministry of Education and Research (BMBF), within the framework of the 
-Strategy "Research for Sustainability" ([FONA](www.fona.de/en)) as part of its 
+Strategy "Research for Sustainability" ([FONA](https://www.fona.de/en/)) as part of its 
 Social-Ecological Research funding priority, funding no. 01UT2102A.

--- a/src/AquaCrop.jl
+++ b/src/AquaCrop.jl
@@ -5,6 +5,7 @@ using DataFrames
 using Unitful: Quantity, FreeUnits, Unit, 𝐋, 𝚯, 𝐓, 𝐈, 𝐌, NoDims
 using Unitful
 using Dates
+using CSV
 
 
 # ---- includes ----
@@ -39,6 +40,7 @@ export AquaCropField,
        setup_cropfield!,
        change_climate_data!,
        isharvestable,
-       timetoharvest
+       timetoharvest,
+       write_out_csv
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -76,7 +76,7 @@ struct SetupCropField <: AbstractCropFieldStatus end
 
 
 """
-    status = SetupCropField()
+    status = FinishCropField()
 
 Indicates the cropfield has finished running
 """
@@ -120,6 +120,11 @@ end
     season_run!(cropfield::AquaCropField)
 
 Updates the `cropfield` for all days in the current season
+
+In case you upload the data using `NormalFileRun` or `TomlFileRun` and you indicate multiple seasons
+it will only run the first season.
+
+In case you upload the data using `NoFileRun` it runs the simulation from `Simulation_DayNr1` up to `Simulation_DayNrN`.
 """
 function season_run!(cropfield::AquaCropField)
     _season_run!(cropfield.status[1], cropfield)


### PR DESCRIPTION
We do the following changes

1. add `write_out_csv` function on api so we can write the outputs on csv format (comes with tests in doc)
2. fix a url link on the index.md
3. change the docstring of `season_run`
4. correct a typo on docstring of `FinishCropField`