### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/AquaCrop.jl
+++ b/src/AquaCrop.jl
@@ -45,4 +45,3 @@ export AquaCropField,
        timetoharvest,
        write_out_csv
 end
-

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,7 +2,7 @@ abstract type AbstractCropField end
 
 
 """
-   AquaCropField 
+   AquaCropField
 
 Has all the data for the simulation of a `cropfield::AquaCropField` variable
 stored in dictionaries.
@@ -12,7 +12,7 @@ Initialize an object of this type using the function
 `cropfield`.
 
 See also [`start_cropfield`](@ref)
-""" 
+"""
 struct AquaCropField <: AbstractCropField
     "global variables"
     gvars::Dict
@@ -26,7 +26,7 @@ end
 
 function Base.getindex(b::AquaCropField, s::Symbol)
     if s in fieldnames(AquaCropField)
-        return getfield(b, s) 
+        return getfield(b, s)
     elseif s in keys(b.outputs)
         return getfield(b, :outputs)[s]
     else
@@ -36,7 +36,7 @@ end
 
 function Base.getproperty(b::AquaCropField, s::Symbol)
     if s in fieldnames(AquaCropField)
-        return getfield(b, s) 
+        return getfield(b, s)
     elseif s in keys(b.outputs)
         return getfield(b, :outputs)[s]
     else
@@ -151,12 +151,12 @@ function _season_run!(status::SetupCropField, cropfield::AquaCropField)
 end
 
 """
-    harvest!(cropfield::AquaCropField) 
+    harvest!(cropfield::AquaCropField)
 
-Indicates to make a harvest on the `cropfield` 
+Indicates to make a harvest on the `cropfield`
 it also makes a daily update along with the harvest
 """
-function harvest!(cropfield::AquaCropField) 
+function harvest!(cropfield::AquaCropField)
     _harvest!(cropfield.status[1], cropfield)
 end
 
@@ -172,38 +172,38 @@ function _harvest!(status::SetupCropField, cropfield::AquaCropField)
         # the crop is not harvestable only do a dailyupdate
         _dailyupdate!(status, cropfield)
         return nothing
-    end 
+    end
 
 
 
     # the status is correct then do something
     gvars = cropfield.gvars
 
-    cutlog = gvars[:management].Cuttings.Considered 
+    cutlog = gvars[:management].Cuttings.Considered
     gvars[:management].Cuttings.Considered = true
 
     genlog = gvars[:management].Cuttings.Generate
     gvars[:management].Cuttings.Generate = false
 
-    if gvars[:management].Cuttings.FirstDayNr != undef_int 
+    if gvars[:management].Cuttings.FirstDayNr != undef_int
        # adjust DayInSeason
         dayinseason = gvars[:integer_parameters][:daynri] - gvars[:management].Cuttings.FirstDayNr + 1
     else
         dayinseason = gvars[:integer_parameters][:daynri] - gvars[:crop].Day1 + 1
-    end 
+    end
 
     cut_info_record1 = deepcopy(gvars[:cut_info_record1])
     gvars[:cut_info_record1].FromDay = dayinseason
-    gvars[:cut_info_record1].NoMoreInfo = false 
+    gvars[:cut_info_record1].NoMoreInfo = false
 
     Man = deepcopy(gvars[:array_parameters][:Man])
     Man_info = deepcopy(gvars[:array_parameters][:Man_info])
 
-    _dailyupdate!(status, cropfield) 
+    _dailyupdate!(status, cropfield)
 
     cropfield.gvars[:cut_info_record1] = cut_info_record1
-    cropfield.gvars[:management].Cuttings.Considered = cutlog 
-    cropfield.gvars[:management].Cuttings.Generate = genlog 
+    cropfield.gvars[:management].Cuttings.Considered = cutlog
+    cropfield.gvars[:management].Cuttings.Generate = genlog
     setparameter!(cropfield.gvars[:array_parameters], :Man, Man)
     setparameter!(cropfield.gvars[:array_parameters], :Man_info, Man_info)
 
@@ -220,7 +220,7 @@ function biomass(cropfield::AquaCropField)
 end
 
 function _biomass(status::T, cropfield::AquaCropField) where T<:AbstractCropFieldStatus
-    # by default return missing 
+    # by default return missing
     missing
 end
 
@@ -241,7 +241,7 @@ function dryyield(cropfield::AquaCropField)
 end
 
 function _dryyield(status::T, cropfield::AquaCropField) where T<:AbstractCropFieldStatus
-    # by default return missing 
+    # by default return missing
     missing
 end
 
@@ -262,7 +262,7 @@ function freshyield(cropfield::AquaCropField)
 end
 
 function _freshyield(status::T, cropfield::AquaCropField) where T<:AbstractCropFieldStatus
-    # by default return missing 
+    # by default return missing
     missing
 end
 
@@ -293,14 +293,14 @@ function canopycover(cropfield::AquaCropField; actual=true)
 end
 
 function _canopycover(status::T, cropfield::AquaCropField, actual) where T<:AbstractCropFieldStatus
-    # by default return missing 
+    # by default return missing
     missing
 end
 
 function _canopycover(status::T, cropfield::AquaCropField, actual) where {T<:Union{SetupCropField, FinishCropField}}
     # the status is correct then return something
     gvars = cropfield.gvars
-    if actual 
+    if actual
         return gvars[:float_parameters][:cciactual] * 100
     else
         return gvars[:float_parameters][:cciprev] * 100
@@ -314,31 +314,31 @@ end
 Runs a basic AquaCrop simulation, the `outputs` variable has the final dataframes
 with the results of the simulation
 
-`runtype` allowed for now is `NormalFileRun` or `TomlFileRun` 
+`runtype` allowed for now is `NormalFileRun` or `TomlFileRun`
 
 `NormalFileRun` will use the input from a files like in AquaCrop Fortran (see AquaCrop.jl/test/testcase)
 
 `TomlFileRun` will use the input from TOML files (see AquaCrop.jl/test/testcase/TOML_FILES)
 
-You can see the daily result in `outputs[:dayout]` 
+You can see the daily result in `outputs[:dayout]`
 the result of each harvest in `outputs[:harvestsout]`
 the result of the whole season in `outputs[:seasonout]`
 the information for the evaluation in `outputs[:evaldataout]`
 and the logger information in `outputs[:logger]`
 """
-function basic_run(; kwargs...) 
+function basic_run(; kwargs...)
     outputs = start_outputs()
     kwargs, all_ok = check_kwargs(outputs; kwargs...)
     if !all_ok.logi
         add_output_in_logger!(outputs, all_ok.msg)
         finalize_outputs!(outputs)
-        return outputs 
+        return outputs
     end
 
     parentdir = kwargs[:parentdir]
 
     start_the_program!(outputs, parentdir; kwargs...)
-    return outputs 
+    return outputs
 end
 
 """
@@ -348,7 +348,7 @@ If we do not have a `kwarg` for `:runtype` it sets it to `NormalFileRun`.
 If we do have that `kwarg`, then checks if it is an `AbstractRunType`.
 
 After calling this function check if `all_ok.logi == true`
-        
+
 ## Examples
 ```jldoctest
 julia> kwargs, all_ok = AquaCrop.check_runtype(Dict(:logger => String[]); runtype = TomlFileRun());
@@ -358,25 +358,25 @@ true
 ```
 """
 function check_runtype(outputs; kwargs...)
-    all_ok = AllOk(true, "") 
-    if !haskey(kwargs, :runtype) 
+    all_ok = AllOk(true, "")
+    if !haskey(kwargs, :runtype)
         kwargs = merge(kwargs, Dict(:runtype => NormalFileRun()))
         add_output_in_logger!(outputs, "using default NormalFileRun")
-    elseif typeof(kwargs[:runtype]) <: AbstractRunType 
+    elseif typeof(kwargs[:runtype]) <: AbstractRunType
         add_output_in_logger!(outputs, "using runtype "*string(kwargs[:runtype]))
-    else 
+    else
         all_ok.logi = false
         all_ok.msg = "invalid runtype "*string(kwargs[:runtype])
     end
 
-    return kwargs, all_ok 
+    return kwargs, all_ok
 end
 
 """
     kwargs, all_ok = check_parentdir(outputs; kwargs...)
 
 If we do not have a `kwarg` for `parentdir` it sets it to `pwd()`.
-If we do have that `kwarg`, then checks if that directory exists. 
+If we do have that `kwarg`, then checks if that directory exists.
 
 After calling this function check if `all_ok.logi == true`
 
@@ -389,18 +389,18 @@ true
 ```
 """
 function check_parentdir(outputs; kwargs...)
-    all_ok = AllOk(true, "") 
-    if !haskey(kwargs, :parentdir) 
+    all_ok = AllOk(true, "")
+    if !haskey(kwargs, :parentdir)
         kwargs = merge(kwargs, Dict(:parentdir => pwd()))
         add_output_in_logger!(outputs, "using default parentdir pwd()")
-    elseif isdir(kwargs[:parentdir]) 
+    elseif isdir(kwargs[:parentdir])
         add_output_in_logger!(outputs, "using given parentdir")
-    else 
+    else
         all_ok.logi = false
         all_ok.msg = "invalid parentdir"
     end
 
-    return kwargs, all_ok 
+    return kwargs, all_ok
 end
 
 """
@@ -450,12 +450,12 @@ true
 ```
 """
 function check_nofilerun(outputs; kwargs...)
-    all_ok = AllOk(true, "") 
+    all_ok = AllOk(true, "")
     # sanity check
     if !(haskey(kwargs, :runtype)) || !(typeof(kwargs[:runtype]) <: NoFileRun)
         all_ok.logi = false
         all_ok.msg = "need kwargs[:runtype] == NoFileRun()"
-        return kwargs, all_ok 
+        return kwargs, all_ok
     end
 
     ## These are keys for starting the cropfield
@@ -472,7 +472,7 @@ function check_nofilerun(outputs; kwargs...)
     # soil
     soil_types = ["sandy clay", "clay", "clay loam", "loamy sand", "loam", "sand", "silt", "silty loam", "silty clay",
                   "sandy clay loam", "sandy loam", "silty clay loam", "paddy"]
-    if !haskey(kwargs, :soil_type) 
+    if !haskey(kwargs, :soil_type)
         all_ok.logi = false
         all_ok.msg = "missing  necessary keyword :soil_type"
         return kwargs, all_ok
@@ -489,7 +489,7 @@ function check_nofilerun(outputs; kwargs...)
                     "maizeGDD", "wheatGDD", "sugarbeet", "sugarbeetGDD", "sunflower", "sunflowerGDD", "sugarcane",
                     "tomato", "tomatoGDD", "potato", "potatoGDD", "quinoa", "tef", "soybean", "soybeanGDD",
                     "sorghum", "sorghumGDD", "paddyrice", "paddyriceGDD", "rapeseed", "oat"]
-    if !haskey(kwargs, :crop_type) 
+    if !haskey(kwargs, :crop_type)
         all_ok.logi = false
         all_ok.msg = "missing  necessary keyword :crop_type"
     elseif !(kwargs[:crop_type] in crop_types)
@@ -516,7 +516,7 @@ end
 
 
 """
-    kwargs, all_ok = check_kwargs(outputs; kwargs...)    
+    kwargs, all_ok = check_kwargs(outputs; kwargs...)
 
 Runs all the necessary checks on the `kwargs`.
 
@@ -549,7 +549,7 @@ function check_kwargs(outputs; kwargs...)
             return kwargs, all_ok
         end
     end
-    
+
     return kwargs, all_ok
 end
 
@@ -557,7 +557,7 @@ end
 """
     cropfield, all_ok = start_cropfield(; kwargs...)
 
-Starts the `cropfield::AquaCropField` with the proper runtype. 
+Starts the `cropfield::AquaCropField` with the proper runtype.
 it uses default values for `runtype` and `parentdir` if these
 `kwargs` are missing.
 
@@ -585,7 +585,7 @@ function start_cropfield(; kwargs...)
 
     all_ok = AllOk(true, "")
 
-    filepaths = initialize_the_program(outputs, parentdir; kwargs...) 
+    filepaths = initialize_the_program(outputs, parentdir; kwargs...)
     project_filenames = initialize_project_filenames(outputs, filepaths; kwargs...)
     if length(project_filenames) < nproject
         all_ok.logi = false
@@ -599,7 +599,7 @@ function start_cropfield(; kwargs...)
 
     theprojectfile = project_filenames[nproject]
     theprojecttype = get_project_type(theprojectfile; kwargs...)
-    if theprojecttype == :typenone 
+    if theprojecttype == :typenone
         all_ok.logi = false
         all_ok.msg = "bad projecttype for "*theprojectfile
         add_output_in_logger!(outputs, all_ok.msg)
@@ -643,7 +643,7 @@ end
 # """
 #     setup_cropfield!(cropfield::AquaCropField, all_ok::AllOk; kwargs...)
 #
-# Setups the `cropfield` variable,  and reads the configuration files 
+# Setups the `cropfield` variable,  and reads the configuration files
 # with information about the climate.
 #
 # After calling this function check if `all_ok.logi == true`
@@ -674,8 +674,8 @@ function _setup_cropfield!(status::StartCropField, cropfield::AquaCropField, all
         cropfield.status[1] = BadCropField()
         return nothing
     end
-    
-    try 
+
+    try
         initialize_run_part1!(cropfield.outputs, cropfield.gvars, nrrun; kwargs...)
         initialize_climate!(cropfield.outputs, cropfield.gvars, nrrun; kwargs...)
         initialize_run_part2!(cropfield.outputs, cropfield.gvars, nrrun; kwargs...)
@@ -695,7 +695,7 @@ function _setup_cropfield!(status::StartCropField, cropfield::AquaCropField, all
         cropfield.status[1] = BadCropField()
         return nothing
     end
-     
+
     lvars = initialize_lvars()
     for key in keys(lvars)
         cropfield.lvars[key] = lvars[key]
@@ -703,7 +703,7 @@ function _setup_cropfield!(status::StartCropField, cropfield::AquaCropField, all
 
     add_output_in_logger!(cropfield.outputs, "cropfield setted")
     cropfield.status[1] = SetupCropField()
-    return nothing 
+    return nothing
 end
 
 """
@@ -754,21 +754,21 @@ function _change_climate_data!(status::SetupCropField, cropfield::AquaCropField,
         reset_gdd_variables!(gvars)
     end
 
-    # change the climate 
+    # change the climate
     l_tmin = hasproperty(climate_data, :Tmin)
     l_tmax = hasproperty(climate_data, :Tmax)
     l_eto = hasproperty(climate_data, :ETo)
     l_rain = hasproperty(climate_data, :Rain)
-    
+
     if |(l_rain, l_eto, l_tmax, l_tmin)
         for row in eachrow(climate_data)
             date = row.Date
             day_i = determine_day_nr(date)
             i = day_i - gvars[:simulation].FromDayNr + 1
-            
+
             # temperature
             if l_tmin & l_tmax
-                if length(outputs[:tempdatasim][:tlow]) > i 
+                if length(outputs[:tempdatasim][:tlow]) > i
                     outputs[:tempdatasim][:tlow][i] = row.Tmin
                     outputs[:tempdatasim][:thigh][i] = row.Tmax
                 end
@@ -789,7 +789,7 @@ function _change_climate_data!(status::SetupCropField, cropfield::AquaCropField,
             end
         end
     end
-    
+
     # set new climate for next day if necessary
     if l_date
         read_climate_nextday!(outputs, gvars)
@@ -803,12 +803,12 @@ end
 """
     logi = isharvestable(cropfield::AquaCropField)
 
-If a crop is harvestable returns `true` 
+If a crop is harvestable returns `true`
 
 See also [`timetoharvest`](@ref)
 """
 function isharvestable(cropfield::AquaCropField)
-    return _timetoharvest(cropfield.status[1], cropfield)[2] 
+    return _timetoharvest(cropfield.status[1], cropfield)[2]
 end
 
 """
@@ -826,7 +826,7 @@ end
 
 function _timetoharvest(status::T, cropfield::AquaCropField) where T<:AbstractCropFieldStatus
     # by default do nothing
-    return nothing, nothing 
+    return nothing, nothing
 end
 
 function _timetoharvest(status::T, cropfield::AquaCropField) where {T<:Union{SetupCropField, FinishCropField}}
@@ -836,15 +836,15 @@ function _timetoharvest(status::T, cropfield::AquaCropField) where {T<:Union{Set
     dayi = cropfield.gvars[:integer_parameters][:daynri]
 
     virtualday = dayi - simulation.DelayedDays - crop.Day1
-    
+
     dm = sum(crop.Length[1:4]) # virtual days until crop maturity
 
-    # virtual day is further than crop maturity 
+    # virtual day is further than crop maturity
     if virtualday >= dm
         th = -1 # allready reached crop maturity
         logi = true # maybe should be harvestable
     else
-        if crop.subkind == :Grain 
+        if crop.subkind == :Grain
             dy = (crop.DaysToFlowering + crop.LengthFlowering) - virtualday # remaining days until yield formation
         elseif crop.subkind == :Tubber
             dy = crop.DaysToFlowering - virtualday # remaining days until yield formation
@@ -881,13 +881,13 @@ function write_out_csv(file, cropfield::AquaCropField, field::Symbol; kwargs...)
     write_out_csv(file, cropfield.outputs[field]; kwargs...)
 end
 
-function write_out_csv(file, cropfield::T; kwargs...) where T<:AbstractDataFrame 
+function write_out_csv(file, cropfield::T; kwargs...) where T<:AbstractDataFrame
     if haskey(kwargs, :digits)
         digits = kwargs[:digits]
     else
         digits = 4
     end
-    
+
     CSV.write(file, cropfield;
             transform = (col,val) -> typeof(val)<:Quantity ? round(ustrip(val), digits=digits) : val,
             kwargs... )

--- a/src/filemanagement.jl
+++ b/src/filemanagement.jl
@@ -4,7 +4,7 @@
 run.f90:FileManagement:7807
 """
 function file_management!(outputs, gvars, nrrun; kwargs...)
-    # we create these "lvars" because we need functions that 
+    # we create these "lvars" because we need functions that
     # returns nothing or does not change anything
     lvars = initialize_lvars()
     projectinput = gvars[:projectinput][nrrun]
@@ -39,28 +39,28 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
     # 1. Get ETo
     if gvars[:string_parameters][:eto_file] == "(None)"
         setparameter!(gvars[:float_parameters], :eto, 5.0)
-    end 
+    end
 
     # 2. Get Rain
     if gvars[:string_parameters][:rain_file] == "(None)"
         setparameter!(gvars[:float_parameters], :rain, 0.0)
-    end 
+    end
 
     # 3. Start mode
     if gvars[:bool_parameters][:startmode]
         setparameter!(gvars[:bool_parameters], :startmode, false)
-    end 
+    end
 
     # 4. Get depth and quality of the groundwater
     if !gvars[:simulparam].ConstGwt
         if gvars[:integer_parameters][:daynri] > gvars[:gwtable].DNr2
             get_gwt_set!(gvars, parentdir, gvars[:integer_parameters][:daynri])
-        end 
+        end
         get_z_and_ec_gwt!(gvars)
         if check_for_watertable_in_profile(gvars[:compartments], gvars[:integer_parameters][:ziaqua]/100)
             adjust_for_watertable!(gvars)
-        end 
-    end 
+        end
+    end
 
     # 5. Get Irrigation
     setparameter!(gvars[:float_parameters], :irrigation, 0.0)
@@ -72,38 +72,38 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
         # regrowth
         if gvars[:integer_parameters][:daynri] >= gvars[:crop].Day1
             # time setting for canopy development
-            virtualtimecc = (gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays 
-                             - gvars[:crop].Day1 
+            virtualtimecc = (gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays
+                             - gvars[:crop].Day1
                              + gvars[:integer_parameters][:tadj] + gvars[:crop].DaysToGermination)
             # adjusted time scale
             if virtualtimecc > gvars[:crop].DaysToHarvest
                 virtualtimecc = gvars[:crop].DaysToHarvest
                 # special case where L123 > L1234
-            end 
+            end
             if virtualtimecc > gvars[:crop].DaysToFullCanopy
-                if (gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays - 
+                if (gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays -
                     gvars[:crop].Day1) <= gvars[:crop].DaysToSenescence
-                    virtualtimecc = gvars[:crop].DaysToFullCanopy + 
-                                    round(Int, gvars[:float_parameters][:dayfraction] * ((gvars[:integer_parameters][:daynri] - 
-                                              gvars[:simulation].DelayedDays - 
-                                              gvars[:crop].Day1) + gvars[:integer_parameters][:tadj] + 
-                                              gvars[:crop].DaysToGermination - 
+                    virtualtimecc = gvars[:crop].DaysToFullCanopy +
+                                    round(Int, gvars[:float_parameters][:dayfraction] * ((gvars[:integer_parameters][:daynri] -
+                                              gvars[:simulation].DelayedDays -
+                                              gvars[:crop].Day1) + gvars[:integer_parameters][:tadj] +
+                                              gvars[:crop].DaysToGermination -
                                               gvars[:crop].DaysToFullCanopy)) # slow down
                 else
-                    virtualtimecc = gvars[:integer_parameters][:daynri] - 
+                    virtualtimecc = gvars[:integer_parameters][:daynri] -
                        gvars[:simulation].DelayedDays - gvars[:crop].Day1 # switch time scale
-                end 
-            end 
+                end
+            end
             if gvars[:crop].ModeCycle == :GDDays
-                sumgddadjcc = gvars[:simulation].SumGDDfromDay1 + gvars[:integer_parameters][:gddtadj] + 
+                sumgddadjcc = gvars[:simulation].SumGDDfromDay1 + gvars[:integer_parameters][:gddtadj] +
                               gvars[:crop].GDDaysToGermination
                 if sumgddadjcc > gvars[:crop].GDDaysToHarvest
                     sumgddadjcc = gvars[:crop].GDDaysToHarvest
                     # special case where L123 > L1234
-                end 
+                end
                 if sumgddadjcc > gvars[:crop].GDDaysToFullCanopy
                     if gvars[:simulation].SumGDDfromDay1 <= gvars[:crop].GDDaysToSenescence
-                        sumgddadjcc = gvars[:crop].GDDaysToFullCanopy + 
+                        sumgddadjcc = gvars[:crop].GDDaysToFullCanopy +
                                         round(Int, gvars[:float_parameters][:gddayfraction] *
                                                         (gvars[:simulation].SumGDDfromDay1 +
                                                          gvars[:integer_parameters][:gddtadj] + gvars[:crop].GDDaysToGermination -
@@ -111,73 +111,73 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
                     else
                         sumgddadjcc = gvars[:simulation].SumGDDfromDay1
                         # switch time scale
-                    end 
+                    end
                 end
-            end 
+            end
             # CC initial (at the end of previous day) when simulation starts
             # before regrowth,
             if (gvars[:integer_parameters][:daynri] == gvars[:crop].Day1) &
                (gvars[:integer_parameters][:daynri] > gvars[:simulation].FromDayNr)
                 ratdgdd = 1
                 if (gvars[:crop].ModeCycle == :GDDays) &
-                   (gvars[:crop].GDDaysToFullCanopySF < gvars[:crop].GDDaysToSenescence) 
-                    ratdgdd = (gvars[:crop].DaysToSenescence - gvars[:crop].DaysToFullCanopySF) / 
+                   (gvars[:crop].GDDaysToFullCanopySF < gvars[:crop].GDDaysToSenescence)
+                    ratdgdd = (gvars[:crop].DaysToSenescence - gvars[:crop].DaysToFullCanopySF) /
                               (gvars[:crop].GDDaysToSenescence - gvars[:crop].GDDaysToFullCanopySF)
-                end 
+                end
                 gvars[:simulation].EffectStress = crop_stress_parameters_soil_fertility(gvars[:crop].StressResponse,
-                                                             gvars[:integer_parameters][:stress_sf_adj_new]) 
+                                                             gvars[:integer_parameters][:stress_sf_adj_new])
                 cciprev = ccini_total_from_time_to_ccini(
-                        gvars[:crop].DaysToCCini, 
-                        gvars[:crop].GDDaysToCCini, 
-                        gvars[:crop].DaysToGermination, 
-                        gvars[:crop].DaysToFullCanopy, 
-                        gvars[:crop].DaysToFullCanopySF, 
-                        gvars[:crop].DaysToSenescence, 
-                        gvars[:crop].DaysToHarvest, 
-                        gvars[:crop].GDDaysToGermination, 
-                        gvars[:crop].GDDaysToFullCanopy, 
-                        gvars[:crop].GDDaysToFullCanopySF, 
-                        gvars[:crop].GDDaysToSenescence, 
-                        gvars[:crop].GDDaysToHarvest, gvars[:crop].CCo, 
-                        gvars[:crop].CCx, gvars[:crop].CGC, 
-                        gvars[:crop].GDDCGC, gvars[:crop].CDC, 
-                        gvars[:crop].GDDCDC, ratdgdd, 
-                        gvars[:simulation].EffectStress.RedCGC, 
+                        gvars[:crop].DaysToCCini,
+                        gvars[:crop].GDDaysToCCini,
+                        gvars[:crop].DaysToGermination,
+                        gvars[:crop].DaysToFullCanopy,
+                        gvars[:crop].DaysToFullCanopySF,
+                        gvars[:crop].DaysToSenescence,
+                        gvars[:crop].DaysToHarvest,
+                        gvars[:crop].GDDaysToGermination,
+                        gvars[:crop].GDDaysToFullCanopy,
+                        gvars[:crop].GDDaysToFullCanopySF,
+                        gvars[:crop].GDDaysToSenescence,
+                        gvars[:crop].GDDaysToHarvest, gvars[:crop].CCo,
+                        gvars[:crop].CCx, gvars[:crop].CGC,
+                        gvars[:crop].GDDCGC, gvars[:crop].CDC,
+                        gvars[:crop].GDDCDC, ratdgdd,
+                        gvars[:simulation].EffectStress.RedCGC,
                         gvars[:simulation].EffectStress.RedCCX,
-                        gvars[:simulation].EffectStress.CDecline, 
-                        (gvars[:float_parameters][:ccxtotal]/gvars[:crop].CCx), gvars[:crop].ModeCycle, 
+                        gvars[:simulation].EffectStress.CDecline,
+                        (gvars[:float_parameters][:ccxtotal]/gvars[:crop].CCx), gvars[:crop].ModeCycle,
                         gvars[:simulation])
                 setparameter!(gvars[:float_parameters], :cciprev, cciprev)
                 # (CCxTotal/Crop.CCx) = fWeed
-            end 
+            end
         else
             # before start crop
-            virtualtimecc = gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays - 
+            virtualtimecc = gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays -
                             gvars[:crop].Day1
             if gvars[:crop].ModeCycle == :GDDays
                 sumgddadjcc = gvars[:simulation].SumGDD
-            end 
-        end 
+            end
+        end
     else
         # sown or transplanted
-        virtualtimecc = gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays - 
+        virtualtimecc = gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays -
                         gvars[:crop].Day1
         if gvars[:crop].ModeCycle == :GDDays
             sumgddadjcc = gvars[:simulation].SumGDD
-        end 
+        end
         # CC initial (at the end of previous day) when simulation starts
         # before sowing/transplanting,
         if (gvars[:integer_parameters][:daynri] == (gvars[:crop].Day1 + gvars[:crop].DaysToGermination)) &
-           (gvars[:integer_parameters][:daynri] > gvars[:simulation].FromDayNr) 
+           (gvars[:integer_parameters][:daynri] > gvars[:simulation].FromDayNr)
             setparameter!(gvars[:float_parameters], :cciprev, gvars[:float_parameters][:ccototal])
-        end 
-    end 
+        end
+    end
 
     # 7. Rooting depth AND Inet day 1
     if ((gvars[:crop].ModeCycle == :CalendarDays) &
         ((gvars[:integer_parameters][:daynri]-gvars[:crop].Day1+1) < gvars[:crop].DaysToHarvest)) |
        ((gvars[:crop].ModeCycle == :GDDays) &
-        (gvars[:simulation].SumGDD < gvars[:crop].GDDaysToHarvest)) 
+        (gvars[:simulation].SumGDD < gvars[:crop].GDDaysToHarvest))
         if ((gvars[:integer_parameters][:daynri]-gvars[:simulation].DelayedDays) >= gvars[:crop].Day1) &
            ((gvars[:integer_parameters][:daynri]-gvars[:simulation].DelayedDays) <= gvars[:crop].DayN)
             # rooting depth at DAP (at Crop.Day1, DAP = 1)
@@ -190,22 +190,22 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
                 setparameter!(gvars[:float_parameters], :rooting_depth, gvars[:integer_parameters][:ziaqua]/100)
                 if gvars[:float_parameters][:rooting_depth] < gvars[:crop].RootMin
                     setparameter!(gvars[:float_parameters], :rooting_depth, gvars[:crop].RootMin)
-                end 
-             end 
+                end
+             end
         else
-            setparameter!(gvars[:float_parameters], :rooting_depth, 0.0) 
-        end 
+            setparameter!(gvars[:float_parameters], :rooting_depth, 0.0)
+        end
     else
-        setparameter!(gvars[:float_parameters], :rooting_depth, gvars[:float_parameters][:ziprev]) 
-    end 
+        setparameter!(gvars[:float_parameters], :rooting_depth, gvars[:float_parameters][:ziprev])
+    end
     if (gvars[:float_parameters][:rooting_depth] > 0) & (gvars[:integer_parameters][:daynri] == gvars[:crop].Day1)
         # initial root zone depletion day1 (for WRITE Output)
             determine_root_zone_wc!(gvars, gvars[:float_parameters][:rooting_depth])
         if gvars[:symbol_parameters][:irrimode] == :Inet
             # required to start germination
             adjust_swc_rootzone!(gvars, lvars)
-        end 
-    end 
+        end
+    end
 
     # 8. Transfer of Assimilates
     initialize_transfer_assimilates!(gvars, lvars)
@@ -221,7 +221,7 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
         gvars[:sumwabal].Irrigation += preirri
         setparameter!(gvars[:float_parameters], :irrigation, irrigation + preirri)
         setparameter!(lvars[:float_parameters], :preirri, 0.0)
-     end 
+     end
 
      # total number of days in the season
      if gvars[:float_parameters][:cciactual] > 0
@@ -229,8 +229,8 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
             gvars[:stresstot].NrD = 1
         else
             gvars[:stresstot].NrD += 1
-        end 
-     end 
+        end
+     end
 
     # 10. Potential biomass
     determine_potential_biomass!(gvars, virtualtimecc, sumgddadjcc)
@@ -243,37 +243,37 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
             kstr = 1
         else
             kstr = ks_temperature(0, gvars[:crop].GDtranspLow, gvars[:float_parameters][:gddayi])
-        end 
+        end
         gvars[:stresstot].Temp = ((gvars[:stresstot].NrD - 1)*gvars[:stresstot].Temp + 100*(1-kstr))/gvars[:stresstot].NrD
         # soil salinity stress
         determine_root_zone_salt_content!(gvars, gvars[:float_parameters][:rooting_depth])
         gvars[:stresstot].Salt = ((gvars[:stresstot].NrD - 1)*gvars[:stresstot].Salt +
                                  100*(1-gvars[:root_zone_salt].KsSalt))/gvars[:stresstot].NrD
          # Biomass and yield
-         determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc) 
+         determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
     else
          # SenStage = undef_int #GDL, 20220423, not used
          setparameter!(gvars[:float_parameters], :weedrci, undef_double)  # no crop and no weed infestation
          setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.0)  # no crop
          setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0)  # no crop
-    end 
+    end
 
     # 12. Reset after RUN
     if gvars[:bool_parameters][:preday] == false
         setparameter!(gvars[:integer_parameters], :previoussdaynr, gvars[:simulation].FromDayNr - 1)
-    end 
+    end
     setparameter!(gvars[:bool_parameters], :preday, true)
     if gvars[:integer_parameters][:daynri] >= gvars[:crop].Day1
         setparameter!(gvars[:float_parameters], :cciprev, gvars[:float_parameters][:cciactual])
-        if gvars[:float_parameters][:ziprev] < gvars[:float_parameters][:rooting_depth] 
+        if gvars[:float_parameters][:ziprev] < gvars[:float_parameters][:rooting_depth]
             setparameter!(gvars[:float_parameters], :ziprev, gvars[:float_parameters][:rooting_depth])
             # IN CASE groundwater table does not affect root development
-        end 
+        end
         setparameter!(gvars[:float_parameters], :sumgddprev, gvars[:simulation].SumGDD)
-    end 
+    end
     if lvars[:integer_parameters][:targettimeval] == 1
         setparameter!(gvars[:integer_parameters], :irri_interval, 0)
-    end 
+    end
 
     # 13. Cuttings
     if gvars[:management].Cuttings.Considered
@@ -286,48 +286,48 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
         setparameter!(gvars[:float_parameters], :sumgddcuts, sumgddcuts + gddayi)
 
         if gvars[:management].Cuttings.Generate == false
-            if gvars[:management].Cuttings.FirstDayNr != undef_int 
+            if gvars[:management].Cuttings.FirstDayNr != undef_int
                # adjust DayInSeason
                 dayinseason = gvars[:integer_parameters][:daynri] - gvars[:management].Cuttings.FirstDayNr + 1
-            end 
+            end
             if (dayinseason >= gvars[:cut_info_record1].FromDay) &
                 (gvars[:cut_info_record1].NoMoreInfo == false)
                 setparameter!(lvars[:bool_parameters], :harvestnow, true)
                 get_next_harvest!(gvars)
-            end 
-            if gvars[:management].Cuttings.FirstDayNr != undef_int 
+            end
+            if gvars[:management].Cuttings.FirstDayNr != undef_int
                # reset DayInSeason
                 dayinseason = gvars[:integer_parameters][:daynri] - gvars[:crop].Day1 + 1
-            end 
+            end
         else
             if (dayinseason > gvars[:cut_info_record1].ToDay) &
                 (gvars[:cut_info_record1].NoMoreInfo == false)
                 get_next_harvest!(gvars)
-            end 
+            end
             if gvars[:management].Cuttings.Criterion == :IntDay
                 if (gvars[:integer_parameters][:suminterval] >= gvars[:cut_info_record1].IntervalInfo) &
                    (dayinseason >= gvars[:cut_info_record1].FromDay) &
                    (dayinseason <= gvars[:cut_info_record1].ToDay)
                     setparameter!(lvars[:bool_parameters], :harvestnow, true)
-                end 
+                end
             elseif gvars[:management].Cuttings.Criterion == :IntGDD
                 if (gvars[:float_parameters][:sumgddcuts] >= gvars[:cut_info_record1].IntervalGDD) &
                    (dayinseason >= gvars[:cut_info_record1].FromDay) &
                    (dayinseason <= gvars[:cut_info_record1].ToDay)
                     setparameter!(lvars[:bool_parameters], :harvestnow, true)
-                end 
+                end
             elseif gvars[:management].Cuttings.Criterion == :DryB
                 if ((gvars[:sumwabal].Biomass - gvars[:float_parameters][:bprevsum]) >= gvars[:cut_info_record1].MassInfo) &
                    (dayinseason >= gvars[:cut_info_record1].FromDay) &
                    (dayinseason <= gvars[:cut_info_record1].ToDay)
                     setparameter!(lvars[:bool_parameters], :harvestnow, true)
-                end 
+                end
             elseif gvars[:management].Cuttings.Criterion == :DryY
                 if ((gvars[:sumwabal].YieldPart - gvars[:float_parameters][:yprevsum]) >= gvars[:cut_info_record1].MassInfo) &
                    (dayinseason >= gvars[:cut_info_record1].FromDay) &
                    (dayinseason <= gvars[:cut_info_record1].ToDay)
                     setparameter!(lvars[:bool_parameters], :harvestnow, true)
-                end 
+                end
             elseif gvars[:management].Cuttings.Criterion == :FreshY
                 # OK if Crop.DryMatter = undef_int (not specified) HarvestNow
                 # remains false
@@ -336,10 +336,10 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
                    (dayinseason >= gvars[:cut_info_record1].FromDay) &
                    (dayinseason <= gvars[:cut_info_record1].ToDay)
                     setparameter!(lvars[:bool_parameters], :harvestnow, true)
-                end 
-            end 
-        end 
-        if lvars[:bool_parameters][:harvestnow] 
+                end
+            end
+        end
+        if lvars[:bool_parameters][:harvestnow]
             nrcut = gvars[:integer_parameters][:nrcut]
 
             setparameter!(gvars[:integer_parameters], :nrcut, nrcut + 1)
@@ -348,21 +348,21 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
                 setparameter!(gvars[:float_parameters], :cciprev, gvars[:management].Cuttings.CCcut/100)
                 # ook nog CCwithered
                 gvars[:crop].CCxWithered = 0  # or CCiPrev ??
-                setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.0) 
+                setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.0)
                 # for calculation Maximum Biomass unlimited soil fertility
                 gvars[:crop].CCxAdjusted = gvars[:float_parameters][:cciprev] # new
-            end 
+            end
             # Record harvest
             if gvars[:bool_parameters][:part1Mult]
                 record_harvest!(outputs, gvars, nrcut + 1, dayinseason, nrrun)
-            end 
+            end
             # Reset
             setparameter!(gvars[:integer_parameters], :suminterval, 0)
             setparameter!(gvars[:float_parameters], :sumgddcuts, 0)
             setparameter!(gvars[:float_parameters], :bprevsum, gvars[:sumwabal].Biomass)
             setparameter!(gvars[:float_parameters], :yprevsum, gvars[:sumwabal].YieldPart)
-        end 
-    end 
+        end
+    end
 
     # 14. Write results
     # 14.a Summation
@@ -379,44 +379,44 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
         if gvars[:float_parameters][:stressleaf] > - ac_zero_threshold
             gvars[:stresstot].Exp = ((gvars[:stresstot].NrD - 1)*gvars[:stresstot].Exp +
                                      gvars[:float_parameters][:stressleaf])/(gvars[:stresstot].NrD)
-        end 
+        end
         # stomatal closure
         if gvars[:float_parameters][:tpot] > 0
             stressstomata = 100 *(1 - gvars[:float_parameters][:tact]/gvars[:float_parameters][:tpot])
             if stressstomata > - ac_zero_threshold
                 gvars[:stresstot].Sto = ((gvars[:stresstot].NrD - 1) *
                                          gvars[:stresstot].Sto + stressstomata) / (gvars[:stresstot].NrD)
-            end 
-        end 
-    end 
+            end
+        end
+    end
     # weed stress
     if gvars[:float_parameters][:weedrci] > - ac_zero_threshold
         gvars[:stresstot].Weed =  ((gvars[:stresstot].NrD - 1)*gvars[:stresstot].Weed +
                                      gvars[:float_parameters][:weedrci])/(gvars[:stresstot].NrD)
-    end 
+    end
     # 14.c Assign crop parameters
     gvars[:plotvarcrop].ActVal = gvars[:float_parameters][:cciactual]/gvars[:float_parameters][:ccxcrop_weednosf_stress] * 100
-    gvars[:plotvarcrop].PotVal = 100 * (1/gvars[:float_parameters][:ccxcrop_weednosf_stress]) * 
+    gvars[:plotvarcrop].PotVal = 100 * (1/gvars[:float_parameters][:ccxcrop_weednosf_stress]) *
                                    canopy_cover_no_stress_sf(virtualtimecc+gvars[:simulation].DelayedDays + 1,
-                                     gvars[:crop].DaysToGermination, gvars[:crop].DaysToSenescence, 
-                                     gvars[:crop].DaysToHarvest, gvars[:crop].GDDaysToGermination, 
-                                     gvars[:crop].GDDaysToSenescence, gvars[:crop].GDDaysToHarvest, 
-                                     gvars[:float_parameters][:fweednos]*gvars[:crop].CCo, 
-                                     gvars[:float_parameters][:fweednos]*gvars[:crop].CCx, 
-                                     gvars[:float_parameters][:cgcref], 
+                                     gvars[:crop].DaysToGermination, gvars[:crop].DaysToSenescence,
+                                     gvars[:crop].DaysToHarvest, gvars[:crop].GDDaysToGermination,
+                                     gvars[:crop].GDDaysToSenescence, gvars[:crop].GDDaysToHarvest,
+                                     gvars[:float_parameters][:fweednos]*gvars[:crop].CCo,
+                                     gvars[:float_parameters][:fweednos]*gvars[:crop].CCx,
+                                     gvars[:float_parameters][:cgcref],
                                      gvars[:crop].CDC*(gvars[:float_parameters][:fweednos]*gvars[:crop].CCx + 2.29)/(gvars[:crop].CCx + 2.29),
-                                     gvars[:float_parameters][:gddcgcref], 
-                                     gvars[:crop].GDDCDC*(gvars[:float_parameters][:fweednos]*gvars[:crop].CCx + 2.29)/(gvars[:crop].CCx + 2.29), 
+                                     gvars[:float_parameters][:gddcgcref],
+                                     gvars[:crop].GDDCDC*(gvars[:float_parameters][:fweednos]*gvars[:crop].CCx + 2.29)/(gvars[:crop].CCx + 2.29),
                                      sumgddadjcc, gvars[:crop].ModeCycle, 0, 0,
                                      gvars[:simulation])
     if (virtualtimecc+gvars[:simulation].DelayedDays + 1) <= gvars[:crop].DaysToFullCanopySF
         # not yet canopy decline with soil fertility stress
-        potvalsf = 100 * (1/gvars[:float_parameters][:ccxcrop_weednosf_stress]) * 
+        potvalsf = 100 * (1/gvars[:float_parameters][:ccxcrop_weednosf_stress]) *
                            canopy_cover_no_stress_sf(
-                            virtualtimecc + gvars[:simulation].DelayedDays + 1, 
-                            gvars[:crop].DaysToGermination, 
-                            gvars[:crop].DaysToSenescence, gvars[:crop].DaysToHarvest, 
-                            gvars[:crop].GDDaysToGermination, gvars[:crop].GDDaysToSenescence, 
+                            virtualtimecc + gvars[:simulation].DelayedDays + 1,
+                            gvars[:crop].DaysToGermination,
+                            gvars[:crop].DaysToSenescence, gvars[:crop].DaysToHarvest,
+                            gvars[:crop].GDDaysToGermination, gvars[:crop].GDDaysToSenescence,
                             gvars[:crop].GDDaysToHarvest,
                             gvars[:float_parameters][:ccototal],
                             gvars[:float_parameters][:ccxtotal],
@@ -424,19 +424,19 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
                             gvars[:float_parameters][:cdctotal],
                             gvars[:crop].GDDCGC,
                             gvars[:float_parameters][:gddcdctotal],
-                            sumgddadjcc, gvars[:crop].ModeCycle, 
-                            gvars[:simulation].EffectStress.RedCGC, 
+                            sumgddadjcc, gvars[:crop].ModeCycle,
+                            gvars[:simulation].EffectStress.RedCGC,
                             gvars[:simulation].EffectStress.RedCCX,
                             gvars[:simulation])
     else
         potvalsf = get_potvalsf(virtualtimecc+gvars[:simulation].DelayedDays + 1, sumgddadjcc, gvars)
-    end 
+    end
 
     # 14.d Print ---------------------------------------
     if gvars[:integer_parameters][:outputaggregate] > 0
         check_for_print!(outputs, gvars)
-    end 
-    if gvars[:bool_parameters][:outdaily] 
+    end
+    if gvars[:bool_parameters][:outdaily]
         wpi = lvars[:float_parameters][:wpi]
         dap = gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays - gvars[:crop].Day1 + 1
         write_daily_results!(outputs, gvars, dap, wpi, nrrun)
@@ -447,7 +447,7 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
     if gvars[:bool_parameters][:part2Eval] & (gvars[:string_parameters][:observations_file] != "(None)")
         dap = gvars[:integer_parameters][:daynri] - gvars[:simulation].DelayedDays - gvars[:crop].Day1 + 1
         write_evaluation_data!(outputs, gvars, dap, nrrun)
-    end 
+    end
 
     # 15. Prepare Next day
     # 15.a Date
@@ -457,7 +457,7 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
         setparameter!(gvars[:integer_parameters], :irri_interval, 1)
     else
         setparameter!(gvars[:integer_parameters], :irri_interval, gvars[:integer_parameters][:irri_interval] + 1)
-    end 
+    end
     # 15.c Rooting depth
     # 15.bis extra line for standalone
     if gvars[:bool_parameters][:outdaily]
@@ -466,9 +466,9 @@ function advance_one_time_step!(outputs, gvars, lvars, parentdir, nrrun)
     # 15.extra - reset ageing of Kc at recovery after full senescence
     if gvars[:simulation].SumEToStress >= 0.1
         setparameter!(gvars[:integer_parameters], :daylastcut, gvars[:integer_parameters][:daynri])
-    end 
+    end
     return nothing
-end 
+end
 
 """
     get_z_and_ec_gwt!(gvars)
@@ -482,18 +482,18 @@ function get_z_and_ec_gwt!(gvars)
         ziaqua  = gvars[:gwtable].Z1
         eciaqua = gvars[:gwtable].EC1
     else
-        ziaqua = gvars[:gwtable].Z1 + 
-                 round(Int, (gvars[:integer_parameters][:daynri] - gvars[:gwtable].DNr1) * 
-                            (gvars[:gwtable].Z2 - gvars[:gwtable].Z1) / 
+        ziaqua = gvars[:gwtable].Z1 +
+                 round(Int, (gvars[:integer_parameters][:daynri] - gvars[:gwtable].DNr1) *
+                            (gvars[:gwtable].Z2 - gvars[:gwtable].Z1) /
                             (gvars[:gwtable].DNr2 - gvars[:gwtable].DNr1))
-        eciaqua = gvars[:gwtable].EC1 + 
-                 (gvars[:integer_parameters][:daynri] - gvars[:gwtable].DNr1) * 
+        eciaqua = gvars[:gwtable].EC1 +
+                 (gvars[:integer_parameters][:daynri] - gvars[:gwtable].DNr1) *
                  (gvars[:gwtable].EC2 - gvars[:gwtable].EC1) /
                  (gvars[:gwtable].DNr2 - gvars[:gwtable].DNr1)
-    end 
+    end
     if ziaqua != ziin
         calculate_adjusted_fc!(gvars[:compartments], gvars[:soil_layers], ziaqua/100)
-    end 
+    end
 
     setparameter!(gvars[:integer_parameters], :ziaqua, ziaqua)
     setparameter!(gvars[:float_parameters], :eciaqua, eciaqua)
@@ -511,13 +511,13 @@ function get_irri_param!(gvars, lvars)
 
     targettimeval = -999
     targetdepthval = -999
-    if (gvars[:integer_parameters][:daynri] < gvars[:crop].Day1) | 
+    if (gvars[:integer_parameters][:daynri] < gvars[:crop].Day1) |
        (gvars[:integer_parameters][:daynri] > gvars[:crop].DayN)
         irrigation = irri_out_season(gvars)
         setparameter!(gvars[:float_parameters], :irrigation, irrigation)
     elseif gvars[:symbol_parameters][:irrimode] == :Manual
         irri_manual!(gvars)
-    end 
+    end
     if (gvars[:symbol_parameters][:irrimode] == :Generate) &
        (gvars[:integer_parameters][:daynri] >= gvars[:crop].Day1) &
        (gvars[:integer_parameters][:daynri] <= gvars[:crop].DayN)
@@ -539,17 +539,17 @@ function get_irri_param!(gvars, lvars)
                 timeinfo = Int(popfirst!(Irri_1))
                 depthinfo = Int(popfirst!(Irri_1))
                 irriecw = popfirst!(Irri_4)
-                irri_info_record2.FromDay = fromday 
-                irri_info_record2.TimeInfo = timeinfo 
-                irri_info_record2.DepthInfo = depthinfo 
+                irri_info_record2.FromDay = fromday
+                irri_info_record2.TimeInfo = timeinfo
+                irri_info_record2.DepthInfo = depthinfo
                 gvars[:simulation].IrriECw = irriecw
                 irri_info_record1.ToDay = irri_info_record2.FromDay - 1
-            end 
+            end
             setparameter!(gvars[:array_parameters], :Irri_1, Irri_1)
             setparameter!(gvars[:array_parameters], :Irri_2, Irri_2)
             setparameter!(gvars[:array_parameters], :Irri_3, Irri_3)
             setparameter!(gvars[:array_parameters], :Irri_4, Irri_4)
-        end 
+        end
         # get TargetValues
         targetdepthval = gvars[:irri_info_record1].DepthInfo
         if gvars[:symbol_parameters][:timemode] == :AllDepl
@@ -567,11 +567,11 @@ function get_irri_param!(gvars, lvars)
             else
                 # still to solve
                 targettimeval = 1 # temporary solution
-            end 
+            end
             if (targettimeval == 1) &
                (gvars[:symbol_parameters][:depthmode] == :FixDepth)
                 setparameter!(gvars[:float_parameters], :irrigation, targetdepthval)
-            end 
+            end
 
         elseif gvars[:symbol_parameters][:timemode] == :WaterBetweenBunds
             targettimeval = gvars[:irri_info_record1].TimeInfo
@@ -582,15 +582,15 @@ function get_irri_param!(gvars, lvars)
                 setparameter!(gvars[:float_parameters], :irrigation, targetdepthval)
             else
                 setparameter!(gvars[:float_parameters], :irrigation, 0.0)
-            end 
+            end
             targettimeval = -999 # no need for check in SIMUL
-       end 
-    end 
+       end
+    end
 
     setparameter!(lvars[:integer_parameters], :targettimeval, targettimeval)
     setparameter!(lvars[:integer_parameters], :targetdepthval, targetdepthval)
     return nothing
-end 
+end
 
 """
     irri = irri_out_season(gvars)
@@ -603,13 +603,13 @@ function irri_out_season(gvars)
     dnr = gvars[:integer_parameters][:daynri] - gvars[:simulation].FromDayNr + 1
     for i in 1:5
         irrievents[i] = gvars[:irri_before_season][i]
-    end 
+    end
     if gvars[:integer_parameters][:daynri] > gvars[:crop].DayN
         dnr = gvars[:integer_parameters][:daynri] - gvars[:crop].DayN
         for i in 1:5
             irrievents[i] = gvars[:irri_after_season][i]
-        end 
-    end 
+        end
+    end
     if dnr < 1
         irri = 0
     else
@@ -623,14 +623,14 @@ function irri_out_season(gvars)
                 theend = true
             else
                 irri = 0
-            end 
+            end
             if (nri == 5) | (irrievents[nri].DayNr == 0) |
                (irrievents[nri].DayNr > dnr) |
                (theend)
                loopi = false
            end
         end
-    end 
+    end
     return irri
 end
 
@@ -646,7 +646,7 @@ function irri_manual!(gvars)
         dnr = gvars[:integer_parameters][:daynri] - gvars[:crop].Day1 + 1
     else
         dnr = gvars[:integer_parameters][:daynri] - gvars[:integer_parameters][:irri_first_daynr] + 1
-    end 
+    end
     if irri_info_record1.NoMoreInfo
         irri = 0
     else
@@ -666,36 +666,36 @@ function irri_manual!(gvars)
                 gvars[:simulation].IrriECw = irriecw
                 irri_info_record1.TimeInfo = ir1
                 irri_info_record1.DepthInfo = ir2
-                irri_info_record1.NoMoreInfo = false 
-            end 
+                irri_info_record1.NoMoreInfo = false
+            end
             setparameter!(gvars[:array_parameters], :Irri_1, Irri_1)
             setparameter!(gvars[:array_parameters], :Irri_2, Irri_2)
             setparameter!(gvars[:array_parameters], :Irri_3, Irri_3)
-        end 
-    end 
+        end
+    end
 
     setparameter!(gvars[:float_parameters], :irrigation, irri)
     return nothing
 end
 
 """
-    ccini = ccini_total_from_time_to_ccini(tempdaystoccini, tempgddaystoccini, 
-                                            l0, l12, l12sf, l123, l1234, gddl0, 
-                                            gddl12, gddl12sf, gddl123, 
-                                            gddl1234, cco, ccx, cgc, gddcgc, 
-                                            cdc, gddcdc, ratdgdd, sfredcgc, 
-                                            sfredccx, sfcdecline, fweed, 
+    ccini = ccini_total_from_time_to_ccini(tempdaystoccini, tempgddaystoccini,
+                                            l0, l12, l12sf, l123, l1234, gddl0,
+                                            gddl12, gddl12sf, gddl123,
+                                            gddl1234, cco, ccx, cgc, gddcgc,
+                                            cdc, gddcdc, ratdgdd, sfredcgc,
+                                            sfredccx, sfcdecline, fweed,
                                             themodecycle, simulation)
 
 
 global.f90:CCiniTotalFromTimeToCCini:6408
 """
-function ccini_total_from_time_to_ccini(tempdaystoccini, tempgddaystoccini, 
-                                            l0, l12, l12sf, l123, l1234, gddl0, 
-                                            gddl12, gddl12sf, gddl123, 
-                                            gddl1234, cco, ccx, cgc, gddcgc, 
-                                            cdc, gddcdc, ratdgdd, sfredcgc, 
-                                            sfredccx, sfcdecline, fweed, 
+function ccini_total_from_time_to_ccini(tempdaystoccini, tempgddaystoccini,
+                                            l0, l12, l12sf, l123, l1234, gddl0,
+                                            gddl12, gddl12sf, gddl123,
+                                            gddl1234, cco, ccx, cgc, gddcgc,
+                                            cdc, gddcdc, ratdgdd, sfredcgc,
+                                            sfredccx, sfcdecline, fweed,
                                             themodecycle, simulation)
 
     if tempdaystoccini != 0
@@ -708,30 +708,30 @@ function ccini_total_from_time_to_ccini(tempdaystoccini, tempgddaystoccini,
             tadj = l12 - l0
             if themodecycle == :GDDays
                 gddtadj = gddl12 - gddl0
-            end 
+            end
         else
             # CC on 1st day is < CCx
             tadj = tempdaystoccini
             if themodecycle == :GDDays
                 gddtadj = tempgddaystoccini
-            end 
-        end 
+            end
+        end
         # calculate CCini with adjusted time
         daycc = l0 + tadj
         if themodecycle == :GDDays
             sumgddforccini = gddl0 + gddtadj
-        end 
-        tempccini = cci_no_water_stress_sf(daycc, l0, l12sf, l123, l1234, gddl0, 
-                                       gddl12sf, gddl123, gddl1234, 
-                                       (cco*fweed), (ccx*fweed), cgc, gddcgc, 
-                                       (cdc*(fweed*ccx+2.29)/(ccx+2.29)), 
-                                       (gddcdc*(fweed*ccx+2.29)/(ccx+2.29)), 
-                                       sumgddforccini, ratdgdd, sfredcgc, 
+        end
+        tempccini = cci_no_water_stress_sf(daycc, l0, l12sf, l123, l1234, gddl0,
+                                       gddl12sf, gddl123, gddl1234,
+                                       (cco*fweed), (ccx*fweed), cgc, gddcgc,
+                                       (cdc*(fweed*ccx+2.29)/(ccx+2.29)),
+                                       (gddcdc*(fweed*ccx+2.29)/(ccx+2.29)),
+                                       sumgddforccini, ratdgdd, sfredcgc,
                                        sfredccx, sfcdecline, themodecycle, simulation)
         # correction for fWeed is already in TempCCini (since DayCC > 0);
     else
         tempccini = (cco*fweed) # sowing or transplanting
-    end 
+    end
 
     return tempccini
 end
@@ -742,12 +742,12 @@ end
 rootunit.f90:AdjustedRootingDepth:37
 """
 function adjusted_rooting_depth!(gvars)
-    ccact = gvars[:plotvarcrop].ActVal 
-    ccpot = gvars[:plotvarcrop].PotVal 
-    tpot = gvars[:float_parameters][:tpot] 
-    tact = gvars[:float_parameters][:tact] 
-    stressleaf = gvars[:float_parameters][:stressleaf] 
-    stresssenescence = gvars[:float_parameters][:stresssenescence] 
+    ccact = gvars[:plotvarcrop].ActVal
+    ccpot = gvars[:plotvarcrop].PotVal
+    tpot = gvars[:float_parameters][:tpot]
+    tact = gvars[:float_parameters][:tact]
+    stressleaf = gvars[:float_parameters][:stressleaf]
+    stresssenescence = gvars[:float_parameters][:stresssenescence]
     dap = gvars[:integer_parameters][:daynri] - gvars[:crop].Day1 + 1
     l0 = gvars[:crop].DaysToGermination
     lzmax = gvars[:crop].DaysToMaxRooting
@@ -777,20 +777,20 @@ function adjusted_rooting_depth!(gvars)
             gvars[:soil].RootMax = zmax
         else
             zlimit = zmax
-        end 
+        end
 
         # -- 1.2 Calculate ZiMax
         gvars[:simulation].SCor = 1
         zimax = actual_rooting_depth(dap, l0, lzmax, l1234, gddl0, gddlzmax,
                                 sumgdd, zmin, zmax, shapefactor, typedays, gvars)
         # -- 1.3 Restore effect of restrive soil layer(s)
-        gvars[:soil].RootMax = zlimit 
+        gvars[:soil].RootMax = zlimit
 
         # 2. increase (dZ) at time t
         gvars[:simulation].SCor = 1
         ziunlimm1 = actual_rooting_depth(dap-1, l0, lzmax, l1234, gddl0, gddlzmax,
                                 sumgddprev, zmin, zmax, shapefactor, typedays, gvars)
-        ziunlim = zimax 
+        ziunlim = zimax
 
         dz = ziunlim - ziunlimm1
 
@@ -805,8 +805,8 @@ function adjusted_rooting_depth!(gvars)
             else
                 ksshapefactorroot = gvars[:simulparam].KsShapeFactorRoot
                 dz = dz * (exp((tact/tpot)*ksshapefactorroot)-1) / (exp(ksshapefactorroot)-1) # exponential
-            end 
-        end 
+            end
+        end
 
         # -- 3.2 correction for dry soil at expansion front of actual root
         #        zone
@@ -820,31 +820,31 @@ function adjusted_rooting_depth!(gvars)
             while (zsoil < zitest) & (compi < length(gvars[:compartments]))
                 compi = compi + 1
                 zsoil = zsoil + gvars[:compartments][compi].Thickness
-            end 
+            end
             layer = gvars[:compartments][compi].Layer
             tawcompi = gvars[:soil_layers][layer].FC/100 - gvars[:soil_layers][layer].WP/100
             thetatreshold = gvars[:soil_layers][layer].FC/100 - pzexp * tawcompi
             if gvars[:compartments][compi].Theta < thetatreshold
                 # expansion is limited due to soil water content at
                 # expansion front
-                if gvars[:compartments][compi].Theta <= gvars[:soil_layers][layer].WP/100 
+                if gvars[:compartments][compi].Theta <= gvars[:soil_layers][layer].WP/100
                     dz = 0
                 else
                     wrel = (gvars[:soil_layers][layer].FC/100 - gvars[:compartments][compi].Theta)/tawcompi
                     dz = dz * ks_any(wrel, pzexp, 1, gvars[:crop].KsShapeFactorStomata)
-                end 
-            end 
-        end 
+                end
+            end
+        end
 
         # -- 3.3 correction for early senescence
         if (ccact <= 0) & (ccpot > 50)
             dz = 0
-        end 
+        end
 
         # -- 3.4 correction for no germination
         if !gvars[:simulation].Germinate
             dz = 0
-        end 
+        end
 
         # 4. actual rooting depth (Zi)
         zi = ziprev + dz
@@ -854,7 +854,7 @@ function adjusted_rooting_depth!(gvars)
         if round(Int, zi*1000) < round(Int, zimax*1000)
             # Total extraction in restricted root zone (Zi) and max root
             # zone (ZiMax) should be identical
-            gvars[:simulation].SCor = (2*(zimax/zi)*((gvars[:crop].SmaxTop+gvars[:crop].SmaxBot)/2) - 
+            gvars[:simulation].SCor = (2*(zimax/zi)*((gvars[:crop].SmaxTop+gvars[:crop].SmaxBot)/2) -
                                                       gvars[:crop].SmaxTop)/gvars[:crop].SmaxBot
             # consider part of the restricted deepening due to water stress
             # (= less roots)
@@ -862,15 +862,15 @@ function adjusted_rooting_depth!(gvars)
                 gvars[:simulation].SCor = gvars[:simulation].SCor * gvars[:sumwabal].Tact / gvars[:sumwabal].Tpot
                 if gvars[:simulation].SCor < 1
                     gvars[:simulation].SCor = 1
-                end 
-            end 
+                end
+            end
         else
             gvars[:simulation].SCor = 1
-        end 
-    end 
+        end
+    end
 
     setparameter!(gvars[:float_parameters], :rooting_depth, zi)
-    return nothing 
+    return nothing
 end
 
 """
@@ -879,7 +879,7 @@ end
 global.f90:DetermineRootZoneWC:7787
 """
 function determine_root_zone_wc!(gvars, rootingdepth)
-    root_zone_wc = gvars[:root_zone_wc]  
+    root_zone_wc = gvars[:root_zone_wc]
     compartments = gvars[:compartments]
     soil_layers = gvars[:soil_layers]
     crop = gvars[:crop]
@@ -894,32 +894,32 @@ function determine_root_zone_wc!(gvars, rootingdepth)
 
     # Relative depletion in rootzone and in top soil
     if round(Int, 1000*(root_zone_wc.FC - root_zone_wc.WP)) > 0
-        drrel = (root_zone_wc.FC - root_zone_wc.Actual) / 
+        drrel = (root_zone_wc.FC - root_zone_wc.Actual) /
                 (root_zone_wc.FC - root_zone_wc.WP)
     else
         drrel = 0
-    end 
+    end
     if round(Int, 1000*(root_zone_wc.ZtopFC - root_zone_wc.ZtopWP)) > 0
-        dztoprel = (root_zone_wc.ZtopFC - root_zone_wc.ZtopAct) / 
+        dztoprel = (root_zone_wc.ZtopFC - root_zone_wc.ZtopAct) /
                    (root_zone_wc.ZtopFC - root_zone_wc.ZtopWP)
     else
         dztoprel = 0
-    end 
+    end
 
     # Zone in soil profile considered for determining stress response
     if dztoprel < drrel
         ztopswcconsidered = true  # top soil is relative wetter than root zone
     else
         ztopswcconsidered = false
-    end 
+    end
 
     simulation.SWCtopSoilConsidered = ztopswcconsidered
     return nothing
 end
 
-function _calculate_SWC_in_root_zone!(root_zone_wc::RepRootZoneWC, compartments::Vector{CompartmentIndividual}, soil_layers::Vector{SoilLayerIndividual}, crop::RepCrop, rootingdepth) 
+function _calculate_SWC_in_root_zone!(root_zone_wc::RepRootZoneWC, compartments::Vector{CompartmentIndividual}, soil_layers::Vector{SoilLayerIndividual}, crop::RepCrop, rootingdepth)
     cumdepth = 0
-    root_zone_wc.Actual = 0 
+    root_zone_wc.Actual = 0
     root_zone_wc.FC = 0
     root_zone_wc.WP = 0
     root_zone_wc.SAT = 0
@@ -938,37 +938,37 @@ function _calculate_SWC_in_root_zone!(root_zone_wc::RepRootZoneWC, compartments:
             else
                 factor = 0
             end
-        end 
-        root_zone_wc.Actual = root_zone_wc.Actual + factor * 1000 * 
-                              compartments[compi].Theta * compartments[compi].Thickness * 
+        end
+        root_zone_wc.Actual = root_zone_wc.Actual + factor * 1000 *
+                              compartments[compi].Theta * compartments[compi].Thickness *
                               (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        root_zone_wc.FC = root_zone_wc.FC + factor * 10 * 
+        root_zone_wc.FC = root_zone_wc.FC + factor * 10 *
                           soil_layers[compartments[compi].Layer].FC * compartments[compi].Thickness *
                           (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        root_zone_wc.Leaf = root_zone_wc.Leaf + factor * 10 * compartments[compi].Thickness * 
+        root_zone_wc.Leaf = root_zone_wc.Leaf + factor * 10 * compartments[compi].Thickness *
                             (soil_layers[compartments[compi].Layer].FC - crop.pLeafAct *
                              (soil_layers[compartments[compi].Layer].FC -
                               soil_layers[compartments[compi].Layer].WP)) *
                             (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        root_zone_wc.Thresh = root_zone_wc.Thresh + factor * 10 * compartments[compi].Thickness * 
+        root_zone_wc.Thresh = root_zone_wc.Thresh + factor * 10 * compartments[compi].Thickness *
                               (soil_layers[compartments[compi].Layer].FC - crop.pActStom *
                                (soil_layers[compartments[compi].Layer].FC -
                                 soil_layers[compartments[compi].Layer].WP)) *
                               (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        root_zone_wc.Sen = root_zone_wc.Sen + factor * 10 * compartments[compi].Thickness * 
+        root_zone_wc.Sen = root_zone_wc.Sen + factor * 10 * compartments[compi].Thickness *
                            (soil_layers[compartments[compi].Layer].FC - crop.pSenAct *
                             (soil_layers[compartments[compi].Layer].FC -
                              soil_layers[compartments[compi].Layer].WP)) *
                            (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        root_zone_wc.WP = root_zone_wc.WP + factor * 10 * 
-                          soil_layers[compartments[compi].Layer].WP * 
+        root_zone_wc.WP = root_zone_wc.WP + factor * 10 *
+                          soil_layers[compartments[compi].Layer].WP *
                           compartments[compi].Thickness *
                           (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        root_zone_wc.SAT = root_zone_wc.SAT+ factor * 10 * 
-                           soil_layers[compartments[compi].Layer].SAT * 
+        root_zone_wc.SAT = root_zone_wc.SAT+ factor * 10 *
+                           soil_layers[compartments[compi].Layer].SAT *
                            compartments[compi].Thickness *
                            (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-        if cumdepth >= rootingdepth 
+        if cumdepth >= rootingdepth
             break
         end
     end
@@ -998,17 +998,17 @@ function _calculate_SWC_in_top_soil!(root_zone_wc::RepRootZoneWC, compartments::
                     factor = frac_value/compartments[compi].Thickness
                 else
                     factor = 0
-                end 
-            end 
+                end
+            end
             root_zone_wc.ZtopAct = root_zone_wc.ZtopAct + factor * 1000 *
                                    compartments[compi].Theta * compartments[compi].Thickness *
                                    (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-            root_zone_wc.ZtopFC = root_zone_wc.ZtopFC + factor * 10 * 
-                                  soil_layers[compartments[compi].Layer].FC * 
+            root_zone_wc.ZtopFC = root_zone_wc.ZtopFC + factor * 10 *
+                                  soil_layers[compartments[compi].Layer].FC *
                                   compartments[compi].Thickness *
                                   (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
             root_zone_wc.ZtopWP = root_zone_wc.ZtopWP + factor * 10 *
-                                  soil_layers[compartments[compi].Layer].WP * 
+                                  soil_layers[compartments[compi].Layer].WP *
                                   compartments[compi].Thickness *
                                   (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
             root_zone_wc.ZtopThresh = root_zone_wc.ZtopThresh + factor * 10 *
@@ -1017,11 +1017,11 @@ function _calculate_SWC_in_top_soil!(root_zone_wc::RepRootZoneWC, compartments::
                                        (soil_layers[compartments[compi].Layer].FC -
                                         soil_layers[compartments[compi].Layer].WP)) *
                                       (1 - soil_layers[compartments[compi].Layer].GravelVol/100)
-            if cumdepth >= topsoilinmeter 
+            if cumdepth >= topsoilinmeter
                 break
             end
-        end 
-    end 
+        end
+    end
 
     return nothing
 end
@@ -1045,13 +1045,13 @@ function adjust_swc_rootzone!(gvars, lvars)
         compi = compi + 1
         sumdepth = sumdepth + compartments[compi].Thickness
         layeri = compartments[compi].Layer
-        thetapercraw = soil_layers[layeri].FC/100 - simulparam.PercRAW/100 * crop.pdef *  
+        thetapercraw = soil_layers[layeri].FC/100 - simulparam.PercRAW/100 * crop.pdef *
                        (soil_layers[layeri].FC/100 - soil_layers[layeri].WP/100)
         if compartments[compi].Theta < thetapercraw
             preirri = preirri + (thetapercraw - compartments[compi].Theta) *
                       1000 * compartments[compi].Thickness
             compartments[compi].Theta = thetapercraw
-        end 
+        end
         if (sumdepth >= gvars[:float_parameters][:rooting_depth]) |
            (compi == length(compartments))
             loopi = false
@@ -1103,27 +1103,27 @@ function initialize_transfer_assimilates!(gvars, lvars)
                 # switch mobilization off
                 if mobilizationon
                     assimtomobilize = assimmobilized
-                end 
+                end
                 mobilizationon = false
-            end 
+            end
             # Fraction of assimilates transferred
             if mobilizationon
                 tmob = (assimtomobilize-assimmobilized)/assimtomobilize
                 if assimtomobilize > assimmobilized
                     fracassim = (exp(-5*tmob) - 1)/(exp(-5) - 1)
                     if cciactual > (0.9 * ccxtotal * (1 - simulation.EffectStress.RedCCX/100))
-                        fracassim = fracassim * (ccxtotal * 
-                                    (1 - simulation.EffectStress.RedCCX/100) - cciactual) / 
+                        fracassim = fracassim * (ccxtotal *
+                                    (1 - simulation.EffectStress.RedCCX/100) - cciactual) /
                                     (0.1 * ccxtotal * (1 - simulation.EffectStress.RedCCX/100))
-                    end 
+                    end
                     if fracassim < eps()
                         fracassim = 0
-                    end 
+                    end
                 else
                     # everything is mobilized
                     fracassim = 0
-                end 
-            end 
+                end
+            end
 
             if storageon & (crop.Assimilates.Period > 0)
                 if harvestnow
@@ -1136,23 +1136,23 @@ function initialize_transfer_assimilates!(gvars, lvars)
                                      management.Cuttings.CCcut/100)
                     else
                         fracsto = 1
-                    end 
-                end 
+                    end
+                end
                 # Use convex function
-                fracassim = fracsto * crop.Assimilates.Stored/100 * 
+                fracassim = fracsto * crop.Assimilates.Stored/100 *
                             (1 - ks_any(
-                            (daynri - simulation.DelayedDays - crop.Day1 + 1 - 
+                            (daynri - simulation.DelayedDays - crop.Day1 + 1 -
                             (crop.DaysToHarvest - crop.Assimilates.Period)) / crop.Assimilates.Period,
                             0, 1, -5))
-            end 
+            end
             if fracassim < 0
                 fracassim = 0
-            end 
+            end
             if fracassim > 1
                 fracassim = 1
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     setparameter!(gvars[:float_parameters], :bin, bin)
     setparameter!(gvars[:float_parameters], :bout, bout)
@@ -1183,34 +1183,34 @@ function determine_potential_biomass!(gvars, virtualtimecc, sumgddadjcc)
 
     # potential biomass - unlimited soil fertiltiy
     # 1. - CCi
-    ccipot = canopy_cover_no_stress_sf(virtualtimecc + simulation.DelayedDays + 1, 
-                                  crop.DaysToGermination, crop.DaysToSenescence, 
-                                  crop.DaysToHarvest, crop.GDDaysToGermination, 
-                                  crop.GDDaysToSenescence, crop.GDDaysToHarvest, 
-                                  crop.CCo, crop.CCx, crop.CGC, 
-                                  crop.CDC, crop.GDDCGC, crop.GDDCDC, 
+    ccipot = canopy_cover_no_stress_sf(virtualtimecc + simulation.DelayedDays + 1,
+                                  crop.DaysToGermination, crop.DaysToSenescence,
+                                  crop.DaysToHarvest, crop.GDDaysToGermination,
+                                  crop.GDDaysToSenescence, crop.GDDaysToHarvest,
+                                  crop.CCo, crop.CCx, crop.CGC,
+                                  crop.CDC, crop.GDDCGC, crop.GDDCDC,
                                   sumgddadjcc, crop.ModeCycle, 0, 0, simulation)
     if ccipot < 0
         ccipot = 0
-    end 
+    end
     if ccipot > ccxwitheredtpotnos
         ccxwitheredtpotnos = ccipot
-    end 
+    end
 
     # 2. - Calculation of Tpot
     if crop.ModeCycle == :CalendarDays
         dap = virtualtimecc
     else
         # growing degree days
-        dap = sum_calendar_days(round(Int, sumgddadjcc), crop.Day1, crop.Tbase, 
+        dap = sum_calendar_days(round(Int, sumgddadjcc), crop.Day1, crop.Tbase,
                     crop.Tupper, simulparam.Tmin, simulparam.Tmax, gvars)
         dap = dap + simulation.DelayedDays # are not considered when working with GDDays
-    end 
-    tpotforb, epottotforb = calculate_etpot(dap, crop.DaysToGermination, crop.DaysToFullCanopy, 
-                   crop.DaysToSenescence, crop.DaysToHarvest, 0, ccipot, 
+    end
+    tpotforb, epottotforb = calculate_etpot(dap, crop.DaysToGermination, crop.DaysToFullCanopy,
+                   crop.DaysToSenescence, crop.DaysToHarvest, 0, ccipot,
                    gvars[:float_parameters][:eto],
-                   crop.KcTop, crop.KcDecline, crop.CCx, 
-                   ccxwitheredtpotnos, crop.CCEffectEvapLate, co2i, gddayi, 
+                   crop.KcTop, crop.KcDecline, crop.CCx,
+                   ccxwitheredtpotnos, crop.CCEffectEvapLate, co2i, gddayi,
                    crop.GDtranspLow, simulation, simulparam)
 
     # 3. - WPi for that day
@@ -1225,18 +1225,18 @@ function determine_potential_biomass!(gvars, virtualtimecc, sumgddadjcc)
         dayiafterflowering = virtualtimecc - crop.DaysToFlowering
         if (daysyieldformation > 0) & (dayiafterflowering < (daysyieldformation/3))
             fswitch = dayiafterflowering/(daysyieldformation/3)
-        end 
+        end
         wpi =  wpi * (1 - (1-crop.WPy/100)*fswitch)
-    end 
+    end
     # 3c - adjustment WPi for CO2
     if round(Int, 100*co2i) != round(Int, 100*CO2Ref)
         wpi = wpi * fadjusted_for_co2(co2i, crop.WP, crop.AdaptedToCO2)
-    end 
+    end
 
     # 4. - Potential Biomass
     if gvars[:float_parameters][:eto] > 0
         biomassunlim = biomassunlim + wpi * tpotforb/gvars[:float_parameters][:eto] # ton/ha
-    end 
+    end
 
     setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, ccxwitheredtpotnos)
     gvars[:sumwabal].BiomassUnlim = biomassunlim
@@ -1257,17 +1257,17 @@ function fadjusted_for_co2(co2i, wpi, percenta)
             ftype = 1 # full correction for c3 crops
         else
             ftype = (40-wpi)/(40-20)
-        end 
-    end 
+        end
+    end
 
     # 2. crop sink strength coefficient: fsink
     fsink = percenta/100
     if fsink < 0
         fsink = 0 # based on face expirements
-    end 
+    end
     if fsink > 1
         fsink = 1 # theoretical adjustment
-    end 
+    end
 
     # 3. correction coefficient for co2: fco2old
     fco2old = undef_int
@@ -1280,13 +1280,13 @@ function fadjusted_for_co2(co2i, wpi, percenta)
                 fw = 1
             else
                 fw = 1 - (550 - co2i)/(550 - CO2Ref)
-            end 
-        end 
+            end
+        end
 
         # 3.2 adjustment for co2
         fco2old = (co2i/CO2Ref)/(1+(co2i-CO2Ref)*((1-fw)*0.000138
             + fw*(0.000138*fsink + 0.001165*(1-fsink))))
-    end 
+    end
 
     # 4. adjusted correction coefficient for co2: fco2adj
     fco2adj = undef_int
@@ -1300,8 +1300,8 @@ function fadjusted_for_co2(co2i, wpi, percenta)
         else
             co2rel = (co2i-CO2Ref)/(2000-CO2Ref)
             fco2adj = 1 + 0.58 * ((exp(co2rel*fshape) - 1)/(exp(fshape) - 1))
-        end 
-    end 
+        end
+    end
 
     # 5. selected adjusted coefficient for co2: fco2
     if co2i <= CO2Ref
@@ -1310,8 +1310,8 @@ function fadjusted_for_co2(co2i, wpi, percenta)
         fco2 = fco2adj
         if (co2i <= 550) & (fco2old < fco2adj)
             fco2 = fco2old
-        end 
-    end 
+        end
+    end
 
     # 6. final adjustment
     fadjustedforco2 = 1 + ftype*(fco2-1)
@@ -1319,11 +1319,11 @@ function fadjusted_for_co2(co2i, wpi, percenta)
 end
 
 """
-    determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc) 
+    determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
 
 simul.f90:DetermineBiomassAndYield:529
 """
-function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc) 
+function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
 
     dayi = gvars[:integer_parameters][:daynri]
     eto = gvars[:float_parameters][:eto]
@@ -1384,17 +1384,17 @@ function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
     if (gvars[:crop].subkind == :Tuber) | (gvars[:crop].subkind == :Grain) |
        (gvars[:crop].subkind == :Vegetative) | (gvars[:crop].subkind == :Forage)
         # DaysToFlowering corresponds with Tuberformation
-        # OJO note that we do not have parenthesis in the original Fortran code then the order 
+        # OJO note that we do not have parenthesis in the original Fortran code then the order
         # of boolean operators might change
         if((gvars[:crop].subkind == :Vegetative) & (gvars[:crop].Planting == :Regrowth)) |
-          ((gvars[:crop].subkind == :Forage) & (gvars[:crop].Planting == :Regrowth)) 
+          ((gvars[:crop].subkind == :Forage) & (gvars[:crop].Planting == :Regrowth))
             alfa = gvars[:crop].HI
         else
             hifinal_temp = gvars[:simulation].HIfinal
-            alfa, hifinal_temp, percentlagphase = harvest_index_day(dayi-gvars[:crop].Day1, gvars[:crop].DaysToFlowering, 
+            alfa, hifinal_temp, percentlagphase = harvest_index_day(dayi-gvars[:crop].Day1, gvars[:crop].DaysToFlowering,
                                    gvars[:crop].HI, gvars[:crop].dHIdt,
-                                   gvars[:float_parameters][:cciactual], 
-                                   gvars[:crop].CCxAdjusted, gvars[:crop].CCxWithered, gvars[:simulparam].PercCCxHIfinal, 
+                                   gvars[:float_parameters][:cciactual],
+                                   gvars[:crop].CCxAdjusted, gvars[:crop].CCxWithered, gvars[:simulparam].PercCCxHIfinal,
                                    gvars[:crop].Planting, hifinal_temp, gvars[:crop], gvars[:simulation])
             gvars[:simulation].HIfinal = hifinal_temp
         end
@@ -1464,10 +1464,10 @@ function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
                     fccx = 1
                 end
                 wdrc_temp = gvars[:management].WeedDeltaRC
-                weedrci, wdrc_temp = get_weed_rc(virtualtimecc, sumgddadjcc, fccx, 
-                                                gvars[:simulation].RCadj, gvars[:management].WeedAdj, wdrc_temp, 
-                                                gvars[:crop].DaysToFullCanopySF, gvars[:crop].DaysToSenescence, 
-                                                gvars[:crop].GDDaysToFullCanopySF, gvars[:crop].GDDaysToSenescence, 
+                weedrci, wdrc_temp = get_weed_rc(virtualtimecc, sumgddadjcc, fccx,
+                                                gvars[:simulation].RCadj, gvars[:management].WeedAdj, wdrc_temp,
+                                                gvars[:crop].DaysToFullCanopySF, gvars[:crop].DaysToSenescence,
+                                                gvars[:crop].GDDaysToFullCanopySF, gvars[:crop].GDDaysToSenescence,
                                                 gvars[:crop].ModeCycle)
                 gvars[:management].WeedDeltaRC = wdrc_temp
             else
@@ -1506,7 +1506,7 @@ function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
         if gvars[:crop].subkind == :Forage
             # only for perennial herbaceous forage crops
             # 1. Mobilize assimilates at start of season
-            if mobilizeassimilates 
+            if mobilizeassimilates
                 # mass to mobilize
                 bin = fracassim * wpi *(trw/eto)  # ton/ha
                 if (assimmobilized + bin) > assimtomobilize
@@ -1520,7 +1520,7 @@ function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
                 end
             end
             # 2. Store assimilates at end of season
-            if storeassimilates 
+            if storeassimilates
                 # mass to store
                 bout = fracassim * wpi *(trw/eto)  # ton/ha
                 # cumulative mass stored
@@ -1577,16 +1577,16 @@ function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
             # 2.3 Relative water content for that day
             determine_root_zone_wc!(gvars, gvars[:float_parameters][:rooting_depth])
             if gvars[:simulation].SWCtopSoilConsidered # top soil is relative wetter than total root zone
-                wrel = (gvars[:root_zone_wc].ZtopFC - gvars[:root_zone_wc].ZtopAct)/ 
+                wrel = (gvars[:root_zone_wc].ZtopFC - gvars[:root_zone_wc].ZtopAct)/
                        (gvars[:root_zone_wc].ZtopFC - gvars[:root_zone_wc].ZtopWP) # top soil
             else
-                wrel = (gvars[:root_zone_wc].FC - gvars[:root_zone_wc].Actual)/ 
+                wrel = (gvars[:root_zone_wc].FC - gvars[:root_zone_wc].Actual)/
                        (gvars[:root_zone_wc].FC - gvars[:root_zone_wc].WP) # total root zone
             end
 
             # 2.4 Failure of Pollination during flowering (alfaMax in percentage)
             if gvars[:crop].subkind == :Grain # - only valid for fruit/grain crops (flowers)
-                if (dayi <= (gvars[:simulation].DelayedDays + gvars[:crop].Day1 + 
+                if (dayi <= (gvars[:simulation].DelayedDays + gvars[:crop].Day1 +
                              gvars[:crop].DaysToFlowering + gvars[:crop].LengthFlowering)) & # calculation limited to flowering period
                    ((gvars[:float_parameters][:cciactual]*100) > gvars[:simulparam].PercCCxHIfinal)
                     # sufficient green canopy remains
@@ -1743,7 +1743,7 @@ function determine_biomass_and_yield!(gvars, lvars, sumgddadjcc, virtualtimecc)
             if bioadj <= eps()
                 stresssfadjnew = 80
             else
-                stresssfadjnew = round(Int, coeffb0 + coeffb1*bioadj + coeffb2*bioadj*bioadj) 
+                stresssfadjnew = round(Int, coeffb0 + coeffb1*bioadj + coeffb2*bioadj*bioadj)
                 if stresssfadjnew < 0
                     stresssfadjnew = gvars[:management].FertilityStress
                 end
@@ -1815,7 +1815,7 @@ end
 
 """
     yeari = year_weighing_factor(cropfirstdaynr)
-    
+
 simul.f90:YearWeighingFactor:1074
 """
 function year_weighing_factor(cropfirstdaynr)
@@ -1829,7 +1829,7 @@ end
 simul.f90:FractionPeriod:1051
 """
 function fraction_period(diflor, crop)
-    if diflor <= eps() 
+    if diflor <= eps()
         fi = 0
     else
         timeperc = 100 * (diflor * 1/crop.LengthFlowering)
@@ -1839,9 +1839,9 @@ function fraction_period(diflor, crop)
             fi = 0.00558 * exp(0.63*log(timeperc)) - 0.000969 * timeperc - 0.00383
             if fi < 0
                 fi = 0
-            end 
-        end 
-    end 
+            end
+        end
+    end
     return fi
 end
 
@@ -1858,27 +1858,27 @@ function fraction_flowering(dayi, crop, simulation)
       f2 = fraction_period(diflor, crop)
       diflor = (dayi-1) - (simulation.DelayedDays + crop.Day1 + crop.DaysToFlowering)
       f1 = fraction_period(diflor, crop)
-      if abs(f1-f2) < ac_zero_threshold 
+      if abs(f1-f2) < ac_zero_threshold
           f = 0
       else
           f = (100 * ((f1+f2)/2)/crop.LengthFlowering)
-      end 
-  end 
+      end
+  end
   return f
-end 
+end
 
 """
-    hiday, hifinal, percentlagphase = harvest_index_day(dap, daystoflower, himax, dhidt, cci, 
-                                  ccxadjusted, theccxwithered, 
-                                  percccxhifinal, tempplanting, 
+    hiday, hifinal, percentlagphase = harvest_index_day(dap, daystoflower, himax, dhidt, cci,
+                                  ccxadjusted, theccxwithered,
+                                  percccxhifinal, tempplanting,
                                   hifinal,
                                   crop, simulation)
 
 global.f90:HarvestIndexDay:5567
 """
-function harvest_index_day(dap, daystoflower, himax, dhidt, cci, 
-                                  ccxadjusted, theccxwithered, 
-                                  percccxhifinal, tempplanting, 
+function harvest_index_day(dap, daystoflower, himax, dhidt, cci,
+                                  ccxadjusted, theccxwithered,
+                                  percccxhifinal, tempplanting,
                                   hifinal,
                                   crop, simulation)
 
@@ -1935,7 +1935,7 @@ function harvest_index_day(dap, daystoflower, himax, dhidt, cci,
         tmax = round(Int, himax/dhidt_local)
         if (hifinal == himax) & (t <= tmax) & ((cci+eps()) <= (percccxhifinal/100)) &
            (theccxwithered > eps()) & (cci < theccxwithered) & (crop.subkind != :Vegetative) &
-           (crop.subkind != :Forage) 
+           (crop.subkind != :Forage)
             hifinal = round(Int, hiday)
         end
         if hiday > hifinal
@@ -1955,10 +1955,10 @@ function bm_range(hiadj)
         bmr = 0
     else
         bmr = (log(hiadj)/0.0562)/100
-    end 
+    end
     if bmr > 1
         bmr = 1
-    end 
+    end
     return bmr
 end
 
@@ -1973,13 +1973,13 @@ function hi_multiplier(ratiobm, rangebm, hiadj)
     rmax = rini + (2/3) * (rend-rini)
     if ratiobm <= rini
         himultiplier = 1
-    elseif ratiobm <= rmax 
+    elseif ratiobm <= rmax
         himultiplier = 1 + (1 + sin(pi*(1.5-(ratiobm-rini)/(rmax-rini))))*(hiadj/200)
     elseif ratiobm <= rend
         himultiplier = 1 + (1 + sin(pi*(0.5+(ratiobm-rmax)/(rend-rmax))))*(hiadj/200)
     else
         himultiplier = 1
-    end 
+    end
 
     return himultiplier
 end
@@ -1997,21 +1997,21 @@ function get_potvalsf(dap, sumgddadjcc, gvars)
     if (crop.ModeCycle == :GDDays) &
        (crop.GDDaysToFullCanopySF < crop.GDDaysToSenescence)
         ratdgdd = (crop.DaysToSenescence-crop.DaysToFullCanopySF)/(crop.GDDaysToSenescence-crop.GDDaysToFullCanopySF)
-    end 
+    end
 
-    potvalsf = cci_no_water_stress_sf(dap, crop.DaysToGermination, 
-                    crop.DaysToFullCanopySF, crop.DaysToSenescence, 
-                    crop.DaysToHarvest, crop.GDDaysToGermination, 
-                    crop.GDDaysToFullCanopySF, crop.GDDaysToSenescence, 
+    potvalsf = cci_no_water_stress_sf(dap, crop.DaysToGermination,
+                    crop.DaysToFullCanopySF, crop.DaysToSenescence,
+                    crop.DaysToHarvest, crop.GDDaysToGermination,
+                    crop.GDDaysToFullCanopySF, crop.GDDaysToSenescence,
                     crop.GDDaysToHarvest,
                     gvars[:float_parameters][:ccototal],
-                    gvars[:float_parameters][:ccxtotal], 
+                    gvars[:float_parameters][:ccxtotal],
                     crop.CGC, crop.GDDCGC,
                     gvars[:float_parameters][:cdctotal],
                     gvars[:float_parameters][:gddcdctotal],
-                    sumgddadjcc, ratdgdd, 
-                    simulation.EffectStress.RedCGC, 
-                    simulation.EffectStress.RedCCX, 
+                    sumgddadjcc, ratdgdd,
+                    simulation.EffectStress.RedCGC,
+                    simulation.EffectStress.RedCCX,
                     simulation.EffectStress.CDecline, crop.ModeCycle,
                     simulation)
     potvalsf = 100 * (1/gvars[:float_parameters][:ccxcrop_weednosf_stress]) * potvalsf
@@ -2034,23 +2034,23 @@ function check_for_print!(outputs, gvars)
         saltin = gvars[:sumwabal].SaltIn - gvars[:previoussum].SaltIn
         saltout = gvars[:sumwabal].SaltOut - gvars[:previoussum].SaltOut
         crsalt = gvars[:sumwabal].CRsalt - gvars[:previoussum].CRsalt
-        write_the_results!(outputs, undef_int, dayn, monthn, yearn, dayn, monthn, 
+        write_the_results!(outputs, undef_int, dayn, monthn, yearn, dayn, monthn,
                              yearn, gvars[:float_parameters][:rain],
                              gvars[:float_parameters][:eto],
                              gvars[:float_parameters][:gddayi],
-                             gvars[:float_parameters][:irrigation], 
+                             gvars[:float_parameters][:irrigation],
                              gvars[:float_parameters][:infiltrated],
                              gvars[:float_parameters][:runoff],
-                             gvars[:float_parameters][:drain], 
+                             gvars[:float_parameters][:drain],
                              gvars[:float_parameters][:crwater],
-                             gvars[:float_parameters][:eact], 
-                             gvars[:float_parameters][:epot], 
-                             gvars[:float_parameters][:tact], 
+                             gvars[:float_parameters][:eact],
+                             gvars[:float_parameters][:epot],
+                             gvars[:float_parameters][:tact],
                              gvars[:float_parameters][:tactweedinfested],
-                             gvars[:float_parameters][:tpot], saltin, saltout, 
+                             gvars[:float_parameters][:tpot], saltin, saltout,
                              crsalt, biomassday, bunlimday,
-                             gvars[:float_parameters][:bin], 
-                             gvars[:float_parameters][:bout], 
+                             gvars[:float_parameters][:bin],
+                             gvars[:float_parameters][:bout],
                              gvars)
         gvars[:previoussum].Biomass = gvars[:sumwabal].Biomass
         gvars[:previoussum].BiomassUnlim = gvars[:sumwabal].BiomassUnlim
@@ -2111,10 +2111,10 @@ function write_intermediate_period!(outputs, gvars)
     bmobper = gvars[:transfer].Bmobilized - gvars[:float_parameters][:previousbmob]
     bstoper = gvars[:simulation].Storage.Btotal - gvars[:float_parameters][:previousbsto]
 
-    write_the_results!(outputs, undef_int, day1, month1, year1, dayn, 
-                         monthn, yearn, rper, etoper, gddper, irriper, infiltper, 
-                         roper, drainper, crwper, eper, exper, trper, trwper, 
-                         trxper, salinper, saloutper, salcrper, biomassper, 
+    write_the_results!(outputs, undef_int, day1, month1, year1, dayn,
+                         monthn, yearn, rper, etoper, gddper, irriper, infiltper,
+                         roper, drainper, crwper, eper, exper, trper, trwper,
+                         trxper, salinper, saloutper, salcrper, biomassper,
                          bunlimper, bmobper, bstoper, gvars)
 
     # reset previous sums
@@ -2173,7 +2173,7 @@ function read_climate_nextday!(outputs, gvars)
             setparameter!(gvars[:float_parameters], :tmin, tmin)
             setparameter!(gvars[:float_parameters], :tmax, tmax)
         end
-    end 
+    end
 
     return nothing
 end
@@ -2190,17 +2190,17 @@ function set_gdd_variables_nextday!(gvars)
     daynri = gvars[:integer_parameters][:daynri]
     gddayi = gvars[:float_parameters][:gddayi]
     if daynri <= simulation.ToDayNr
-        gddayi = degrees_day(crop.Tbase, crop.Tupper, 
+        gddayi = degrees_day(crop.Tbase, crop.Tupper,
                                 gvars[:float_parameters][:tmin],
                                 gvars[:float_parameters][:tmax],
                                 simulparam.GDDMethod)
-        setparameter!(gvars[:float_parameters], :gddayi, gddayi) 
+        setparameter!(gvars[:float_parameters], :gddayi, gddayi)
 
         if daynri >= crop.Day1
             simulation.SumGDD = simulation.SumGDD + gddayi
             simulation.SumGDDfromDay1 = simulation.SumGDDfromDay1 + gddayi
-        end 
-    end 
+        end
+    end
     return nothing
 end
 
@@ -2213,33 +2213,33 @@ function reset_gdd_variables!(gvars)
     simulation = gvars[:simulation]
     daynri = gvars[:integer_parameters][:daynri]
     if daynri <= simulation.ToDayNr
-        gddayi = degrees_day(crop.Tbase, crop.Tupper, 
+        gddayi = degrees_day(crop.Tbase, crop.Tupper,
                                 gvars[:float_parameters][:tmin],
                                 gvars[:float_parameters][:tmax],
                                 simulparam.GDDMethod)
         if daynri >= crop.Day1
             simulation.SumGDD = simulation.SumGDD - gddayi
             simulation.SumGDDfromDay1 = simulation.SumGDDfromDay1 - gddayi
-        end 
-    end 
+        end
+    end
     return nothing
 end
 
 """
-    write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn, 
-                           yearn, rper, etoper, gddper, irriper, infiltper, 
-                           roper, drainper, crwper, eper, exper, trper, trwper, 
-                           trxper, salinper, saloutper, 
-                           salcrper, biomassper, bunlimper, bmobper, bstoper, 
+    write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
+                           yearn, rper, etoper, gddper, irriper, infiltper,
+                           roper, drainper, crwper, eper, exper, trper, trwper,
+                           trxper, salinper, saloutper,
+                           salcrper, biomassper, bunlimper, bmobper, bstoper,
                            gvars)
 
 run.f90:WriteTheResults:4531
 """
-function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn, 
-                           yearn, rper, etoper, gddper, irriper, infiltper, 
-                           roper, drainper, crwper, eper, exper, trper, trwper, 
-                           trxper, salinper, saloutper, 
-                           salcrper, biomassper, bunlimper, bmobper, bstoper, 
+function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
+                           yearn, rper, etoper, gddper, irriper, infiltper,
+                           roper, drainper, crwper, eper, exper, trper, trwper,
+                           trxper, salinper, saloutper,
+                           salcrper, biomassper, bunlimper, bmobper, bstoper,
                            gvars)
 
     arr = Float64[]
@@ -2252,7 +2252,7 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
     if gvars[:bool_parameters][:noyear]
         year1_loc = 9999
         yearn_loc = 9999
-    end 
+    end
     if anumber == undef_int # intermediate results
         push!(arr, 0) # RunNr
     else
@@ -2265,7 +2265,7 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
     # Climatic conditions
     tempreal = round(Int, gddper*10)
     push!(arr, rper) # Rain
-    push!(arr, etoper) # ETo 
+    push!(arr, etoper) # ETo
     push!(arr, tempreal/10) # GD
     push!(arr, gvars[:float_parameters][:co2i]) # CO2
 
@@ -2274,12 +2274,12 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
         ratioe = round(Int, 100*eper/exper)
     else
         ratioe = undef_int
-    end 
+    end
     if trxper > 0
         ratiot = round(Int, 100*trper/trxper)
     else
         ratiot = undef_int
-    end 
+    end
     push!(arr, irriper) # Irri
     push!(arr, infiltper) # Infilt
     push!(arr, roper) # Runoff
@@ -2311,10 +2311,10 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
         brsf = round(Int, 100*biomassper/bunlimper)
         if brsf > 100
             brsf = 100
-        end 
+        end
     else
         brsf = undef_int
-    end 
+    end
     push!(arr, biomassper) # BioMass
     push!(arr, brsf) # Brelative
 
@@ -2328,18 +2328,18 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
             hi = 0
         else
             hi = undef_double
-        end 
-    end 
+        end
+    end
 
     if anumber != undef_int # end of simulation run
         # Water Use Efficiency yield
         if ((gvars[:sumwabal].Tact > 0) | (gvars[:sumwabal].ECropCycle > 0)) &
-           (gvars[:sumwabal].YieldPart > 0) 
+           (gvars[:sumwabal].YieldPart > 0)
             wpy = (gvars[:sumwabal].YieldPart*1000) /
                   ((gvars[:sumwabal].Tact+gvars[:sumwabal].ECropCycle)*10)
         else
             wpy = 0
-        end 
+        end
 
         # Fresh yield
         if (gvars[:crop].DryMatter ==  undef_int) |
@@ -2353,7 +2353,7 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
             push!(arr, gvars[:sumwabal].YieldPart) # Y(dry)
             push!(arr, gvars[:sumwabal].YieldPart/(gvars[:crop].DryMatter/100)) # Y(fresh)
             push!(arr, wpy) # WPet
-        end 
+        end
 
         # Transfer of assimilates
         push!(arr, gvars[:transfer].Bmobilized) # Bin
@@ -2365,7 +2365,7 @@ function write_the_results!(outputs, anumber, day1, month1, year1, dayn, monthn,
         push!(arr, undef_int) # WPet
         push!(arr, bmobper) # Bin
         push!(arr, bstoper) # Bout
-    end 
+    end
 
     # End
     push!(arr, yearn_loc) # DateN year
@@ -2393,15 +2393,15 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
     di, mi, yi =  determine_date(gvars[:integer_parameters][:daynri])
     if gvars[:clim_record].FromY == 1901
         yi = yi - 1901 + 1
-    end 
+    end
     if stagecode == 0
         dap_loc = undef_int # before or after cropping
-    end 
+    end
 
     # 0. info day
     push!(arr, yi) # Date year
-    push!(arr, mi) # Date month 
-    push!(arr, di) # Date day 
+    push!(arr, mi) # Date month
+    push!(arr, di) # Date day
     push!(arr, dap_loc) # DAP
     push!(arr, stagecode) # Stage
 
@@ -2415,13 +2415,13 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
     end
     push!(arr, gvars[:total_water_content].EndDay) # WC()
     push!(arr, gvars[:float_parameters][:rain]) # Rain
-    push!(arr, gvars[:float_parameters][:irrigation]) # Irri 
-    push!(arr, gvars[:float_parameters][:surfacestorage]) # Surf 
-    push!(arr, gvars[:float_parameters][:infiltrated]) # Infilt 
-    push!(arr, gvars[:float_parameters][:runoff]) # RO 
+    push!(arr, gvars[:float_parameters][:irrigation]) # Irri
+    push!(arr, gvars[:float_parameters][:surfacestorage]) # Surf
+    push!(arr, gvars[:float_parameters][:infiltrated]) # Infilt
+    push!(arr, gvars[:float_parameters][:runoff]) # RO
     push!(arr, gvars[:float_parameters][:drain]) # Drain
     push!(arr, gvars[:float_parameters][:crwater]) # CR
-    push!(arr, zi) # Zgwt 
+    push!(arr, zi) # Zgwt
 
     tpot = gvars[:float_parameters][:tpot]
     epot = gvars[:float_parameters][:epot]
@@ -2431,19 +2431,19 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         ratio1 = round(Int, 100 * tact/tpot)
     else
         ratio1 = 100
-    end 
+    end
 
     if (epot+tpot) > 0
         ratio2 = round(Int, 100 * (eact+tact)/(epot+tpot))
     else
         ratio2 = 100
-    end 
+    end
 
     if epot > 0
         ratio3 = round(Int, 100 * eact/epot)
     else
         ratio3 = 100
-    end 
+    end
 
     push!(arr, epot) # Ex
     push!(arr, eact) # E
@@ -2464,12 +2464,12 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         strexp = undef_int
     else
         strexp = round(Int, gvars[:float_parameters][:stressleaf])
-    end 
+    end
     if tpot < eps()
         strsto = undef_int
     else
         strsto = round(Int, 100 * (1 - tact/tpot))
-    end 
+    end
 
     # 3. Salinity stress
     kss = gvars[:root_zone_salt].KsSalt
@@ -2477,7 +2477,7 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         strsalt = undef_int
     else
         strsalt = round(Int, 100 * (1 - kss ))
-    end 
+    end
 
     # 4. Air temperature stress
     cciactual = gvars[:float_parameters][:cciactual]
@@ -2485,33 +2485,33 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         kstr = 1
     else
         kstr = ks_temperature(0, gvars[:crop].GDtranspLow, gvars[:float_parameters][:gddayi])
-    end 
+    end
 
     if kstr < 1
         strtr = round(Int, (1-kstr)*100)
     else
         strtr = 0
-    end 
+    end
 
     # 5. Relative cover of weeds
     if cciactual <= ac_zero_threshold
         strw = undef_int
     else
         strw = round(Int, gvars[:float_parameters][:weedrci])
-    end 
+    end
 
     # 6. WPi adjustemnt
     if gvars[:sumwabal].Biomass <= ac_zero_threshold
         wpi_loc = 0
-    end 
+    end
 
     # 7. Harvest Index
     if (gvars[:sumwabal].Biomass > 0) &
-       (gvars[:sumwabal].YieldPart > 0) 
+       (gvars[:sumwabal].YieldPart > 0)
         hi = 100 * (gvars[:sumwabal].YieldPart)/(gvars[:sumwabal].Biomass)
     else
         hi = undef_double
-    end 
+    end
 
     # 8. Relative Biomass
     if (gvars[:sumwabal].Biomass > 0) &
@@ -2519,10 +2519,10 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         brel = round(Int, 100 * gvars[:sumwabal].Biomass/gvars[:sumwabal].BiomassUnlim)
         if brel > 100
             brel = 100
-        end 
+        end
     else
         brel = undef_int
-    end 
+    end
 
     # 9. Kc coefficient
     eto = gvars[:float_parameters][:eto]
@@ -2530,14 +2530,14 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         kcval = tpot/(eto*kstr)
     else
         kcval = undef_int
-    end 
+    end
 
     # 10. Water Use Efficiency yield
     if ((gvars[:sumwabal].Tact > 0) | (gvars[:sumwabal].ECropCycle > 0)) & (gvars[:sumwabal].YieldPart > 0)
         wpy = (gvars[:sumwabal].YieldPart*1000)/((gvars[:sumwabal].Tact+gvars[:sumwabal].ECropCycle)*10)
     else
         wpy = 0
-    end 
+    end
 
     # Fresh yield
     if (gvars[:crop].DryMatter == undef_int) |
@@ -2545,7 +2545,7 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         yf = undef_double
     else
         yf = gvars[:sumwabal].YieldPart/(gvars[:crop].DryMatter/100)
-    end 
+    end
 
     # write
     push!(arr, gvars[:float_parameters][:gddayi]) # GD
@@ -2580,12 +2580,12 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
             determine_root_zone_wc!(gvars, gvars[:crop].RootMax)
         else
             determine_root_zone_wc!(gvars, gvars[:soil].RootMax)
-        end 
-    end 
+        end
+    end
 
     push!(arr, gvars[:root_zone_wc].Actual) # Wr()
 
-    if rooting_depth < eps() 
+    if rooting_depth < eps()
         gvars[:root_zone_wc].Actual = undef_double
         gvars[:root_zone_wc].FC = undef_double
         gvars[:root_zone_wc].WP = undef_double
@@ -2595,7 +2595,7 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
         gvars[:root_zone_wc].Sen = undef_double
     else
         determine_root_zone_wc!(gvars, rooting_depth)
-    end 
+    end
 
     push!(arr, gvars[:root_zone_wc].Actual) # Wr
     push!(arr, gvars[:root_zone_wc].SAT) # Wr(SAT)
@@ -2612,12 +2612,12 @@ function write_daily_results!(outputs, gvars, dap, wpi, nrrun)
     push!(arr, gvars[:total_salt_content].EndDay) # Salt()
     if rooting_depth < eps()
         saltval = undef_int
-        gvars[:root_zone_salt].ECe = undef_int 
-        gvars[:root_zone_salt].ECsw = undef_int 
-        gvars[:root_zone_salt].KsSalt = 1 
+        gvars[:root_zone_salt].ECe = undef_int
+        gvars[:root_zone_salt].ECsw = undef_int
+        gvars[:root_zone_salt].KsSalt = 1
     else
         saltval = gvars[:root_zone_wc].SAT*gvars[:root_zone_salt].ECe*equiv/100
-    end 
+    end
     push!(arr, saltval) # SaltZ
     push!(arr, gvars[:root_zone_salt].ECe) # ECe
     push!(arr, gvars[:root_zone_salt].ECsw) # ECsw
@@ -2670,10 +2670,10 @@ function record_harvest!(outputs, gvars, nrcut, dayinseason, nrrun)
     if nrcut == 9999
         # last line at end of season
         # maybe use missing
-        dap = 0 
-        interval = 0 
-        biomass = 0 
-        dry_yield = 0 
+        dap = 0
+        interval = 0
+        biomass = 0
+        dry_yield = 0
         fresh_yield = 0
     else
         dap = dayinseason
@@ -2715,7 +2715,7 @@ function write_evaluation_data!(outputs, gvars, dap, nrrun)
     if length(gvars[:array_parameters][:DaynrEval]) > 0
         if gvars[:integer_parameters][:daynri] == gvars[:array_parameters][:DaynrEval][1]
 
-            DaynrEval = gvars[:array_parameters][:DaynrEval] 
+            DaynrEval = gvars[:array_parameters][:DaynrEval]
             CCmeanEval = gvars[:array_parameters][:CCmeanEval]
             CCstdEval = gvars[:array_parameters][:CCstdEval]
             BmeanEval = gvars[:array_parameters][:BmeanEval]
@@ -2797,10 +2797,10 @@ function swcz_soil(gvars)
                 factor = frac_value/compartments[compi].Thickness
             else
                  factor = 0
-            end 
-        end 
+            end
+        end
         swcact = swcact + factor * 10 * compartments[compi].Theta*100 * compartments[compi].Thickness
-        if (round(Int, 100*cumdepth) >= round(Int, 100*zsoil)) | 
+        if (round(Int, 100*cumdepth) >= round(Int, 100*zsoil)) |
            (compi == length(compartments))
             loopi = false
         end
@@ -2812,7 +2812,7 @@ end
     initialize_lvars()
 """
 function initialize_lvars()
-    # we create these "lvars" because we need functions that 
+    # we create these "lvars" because we need functions that
     # returns nothing or does not change anything
     float_parameters = ParametersContainer(Float64)
     setparameter!(float_parameters, :wpi,  0.0) #here
@@ -2866,13 +2866,13 @@ function write_irr_info!(outputs, gvars)
         push!(arr, mi) # Date month
         push!(arr, di) # Date day
         push!(arr, undef_int) # DAP
-        push!(arr, undef_int) # Stage 
-        push!(arr, irrigation) # Irri (mm) 
+        push!(arr, undef_int) # Stage
+        push!(arr, irrigation) # Irri (mm)
         push!(arr, undef_int) # IrriInt (days)
 
         add_output_in_irriinfoout!(outputs, arr)
     else # during growing period AND irrigation event or last day
-        if (daynri == cropdayn) | ((irrigation > 0) & (irrimode == :Inet)) # last day  
+        if (daynri == cropdayn) | ((irrigation > 0) & (irrimode == :Inet)) # last day
             if (irrigation < 0.0001) & (daynri == cropdayn)
                 irrion = false
             else
@@ -2884,23 +2884,23 @@ function write_irr_info!(outputs, gvars)
                 if gvars[:clim_record].FromY == 1901
                     yi = yi -1901 + 1
                 end
-                if i == dapi 
+                if i == dapi
                     irrmm = irrigation
                 else
                     irrmm = 0
-                end 
+                end
                 if irrimode == :Inet # for last day of growing period
                     irrmm = undef_int
                     irrion = false
-                end 
-                if irrion 
+                end
+                if irrion
                     arr = Float64[]
                     push!(arr, yi) # Date year
                     push!(arr, mi) # Date month
                     push!(arr, di) # Date day
                     push!(arr, i) # DAP
-                    push!(arr, undef_int) # Stage 
-                    push!(arr, irrmm) # Irri (mm) 
+                    push!(arr, undef_int) # Stage
+                    push!(arr, irrmm) # Irri (mm)
                     push!(arr, dapi - lastirridap) # IrriInt (days)
 
                     add_output_in_irriinfoout!(outputs, arr)
@@ -2910,16 +2910,16 @@ function write_irr_info!(outputs, gvars)
                     push!(arr, mi) # Date month
                     push!(arr, di) # Date day
                     push!(arr, i) # DAP
-                    push!(arr, undef_int) # Stage 
-                    push!(arr, irrmm) # Irri (mm) 
+                    push!(arr, undef_int) # Stage
+                    push!(arr, irrmm) # Irri (mm)
                     push!(arr, undef_int) # IrriInt (days)
 
                     add_output_in_irriinfoout!(outputs, arr)
-                end 
-            end 
+                end
+            end
             if irrion
                 setparameter!(gvars[:integer_parameters], :last_irri_dap, dapi)
-            end 
-        end 
-    end 
+            end
+        end
+    end
 end

--- a/src/initialize_runpart1.jl
+++ b/src/initialize_runpart1.jl
@@ -6,15 +6,15 @@ run.f90:InitializeRunPart1:6568
 function initialize_run_part1!(outputs, gvars, nrrun; kwargs...)
     projectinput = gvars[:projectinput][nrrun]
     load_simulation_project!(outputs, gvars, projectinput; kwargs...)
-    adjust_compartments!(gvars) 
+    adjust_compartments!(gvars)
     # reset sumwabal and previoussum
-    gvars[:sumwabal] = RepSum() 
+    gvars[:sumwabal] = RepSum()
     reset_previous_sum!(gvars)
 
     initialize_simulation_run_part1!(outputs, gvars, projectinput; kwargs...)
 
     return nothing
-end 
+end
 
 """
     initialize_simulation_run_part1!(outputs, gvars, projectinput; kwargs...)
@@ -29,19 +29,19 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
     # 1.1 Adjust soil water and salt content if water table IN soil profile
     if check_for_watertable_in_profile(gvars[:compartments], gvars[:integer_parameters][:ziaqua]/100)
         adjust_for_watertable!(gvars)
-    end 
+    end
     if !gvars[:simulparam].ConstGwt
         get_gwt_set!(gvars, projectinput.ParentDir, gvars[:simulation].FromDayNr)
-    end 
+    end
 
     # 1.2 Check if FromDayNr simulation needs to be adjusted
     # from previous run if Keep initial SWC
-    if (projectinput.SWCIni_Filename=="KeepSWC") & (gvars[:integer_parameters][:nextsim_from_daynr] != undef_int) 
+    if (projectinput.SWCIni_Filename=="KeepSWC") & (gvars[:integer_parameters][:nextsim_from_daynr] != undef_int)
         # assign the adjusted DayNr defined in previous run
         if gvars[:integer_parameters][:nextsim_from_daynr] <= gvars[:crop].Day1
             gvars[:simulation].FromDayNr = gvars[:integer_parameters][:nextsim_from_daynr]
-        end 
-    end 
+        end
+    end
     setparameter!(gvars[:integer_parameters], :nextsim_from_daynr, undef_int)
 
     # 2. initial settings for Crop
@@ -59,13 +59,13 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
     # days of anaerobic conditions in
     # global root zone
     gvars[:simulation].DayAnaero = 0
-    
+
 
     # germination
     if (gvars[:crop].Planting == :Seed) & (gvars[:simulation].FromDayNr<=gvars[:crop].Day1)
         gvars[:simulation].Germinate = false
     else
-        gvars[:simulation].Germinate = true 
+        gvars[:simulation].Germinate = true
         gvars[:simulation].ProtectedSeedling = false
     end
     # delayed germination
@@ -91,7 +91,7 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
     end
 
     if typeof(kwargs[:runtype]) != NoFileRun
-        setparameter!(gvars[:float_parameters], :co2i, 
+        setparameter!(gvars[:float_parameters], :co2i,
                       co2_for_simulation_period(gvars[:string_parameters][:CO2_file], dnr1, dnr2)
                       )
     else
@@ -122,19 +122,19 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
     relationships_for_fertility_and_salt_stress!(outputs, gvars; kwargs...)
 
     # No soil fertility stress
-    if gvars[:management].FertilityStress <= 0 
+    if gvars[:management].FertilityStress <= 0
         gvars[:management].FertilityStress = 0
     end
 
     # Reset soil fertility parameters to selected value in management
     gvars[:simulation].EffectStress = crop_stress_parameters_soil_fertility(gvars[:crop].StressResponse, gvars[:management].FertilityStress)
-    l12sf, redcgc, redccx, classsf = time_to_max_canopy_sf(gvars[:crop].CCo, gvars[:crop].CGC, gvars[:crop].CCx, 
+    l12sf, redcgc, redccx, classsf = time_to_max_canopy_sf(gvars[:crop].CCo, gvars[:crop].CGC, gvars[:crop].CCx,
         gvars[:crop].DaysToGermination, gvars[:crop].DaysToFullCanopy,
         gvars[:crop].DaysToSenescence, gvars[:crop].DaysToFlowering,
         gvars[:crop].LengthFlowering, gvars[:crop].DeterminancyLinked,
         gvars[:crop].DaysToFullCanopySF, gvars[:simulation].EffectStress.RedCGC,
         gvars[:simulation].EffectStress.RedCCX, gvars[:management].FertilityStress)
-    
+
     gvars[:crop].DaysToFullCanopySF = l12sf
     gvars[:simulation].EffectStress.RedCGC = redcgc
     gvars[:simulation].EffectStress.RedCCX = redccx
@@ -143,8 +143,8 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
     setparameter!(gvars[:integer_parameters], :previous_stress_level, gvars[:management].FertilityStress)
     setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, gvars[:management].FertilityStress)
     # soil fertility and GDDays
-    if gvars[:crop].ModeCycle == :GDDays 
-        if gvars[:management].FertilityStress != 0 
+    if gvars[:crop].ModeCycle == :GDDays
+        if gvars[:management].FertilityStress != 0
             gvars[:crop].GDDaysToFullCanopySF = growing_degree_days(
                                                     gvars[:crop].DaysToFullCanopySF,
                                                     gvars[:crop].Day1,
@@ -153,10 +153,10 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
                                                     gvars,
                                                     gvars[:simulparam].Tmin,
                                                     gvars[:simulparam].Tmax
-                                                ) 
+                                                )
         else
             gvars[:crop].GDDaysToFullCanopySF = gvars[:crop].GDDaysToFullCanopy
-        end 
+        end
     end
 
     # Maximum sum Kc (for reduction WP in season if soil fertility stress)
@@ -168,7 +168,7 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
             gvars[:crop].GDDaysToFullCanopy, gvars[:crop].GDDaysToSenescence,
             gvars[:crop].GDDaysToHarvest, gvars[:crop].CCo, gvars[:crop].CCx,
             gvars[:crop].CGC, gvars[:crop].GDDCGC, gvars[:crop].CDC, gvars[:crop].GDDCDC,
-            gvars[:crop].KcTop, gvars[:crop].KcDecline, gvars[:crop].CCEffectEvapLate, 
+            gvars[:crop].KcTop, gvars[:crop].KcDecline, gvars[:crop].CCEffectEvapLate,
             gvars[:crop].Tbase, gvars[:crop].Tupper, gvars[:simulparam].Tmin,
             gvars[:simulparam].Tmax, gvars[:crop].GDtranspLow, gvars[:float_parameters][:co2i],
             gvars[:crop].ModeCycle, gvars[:simulation], gvars[:simulparam], true)
@@ -186,42 +186,42 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
         fi = multiplier_ccx_self_thinning(gvars[:simulation].YearSeason, gvars[:crop].YearCCx, gvars[:crop].CCxRoot)
     else
         fi = 1
-    end 
+    end
     # 7.2 fweed
-    if gvars[:management].WeedRC > 0 
+    if gvars[:management].WeedRC > 0
         fweednos = cc_multiplier_weed(gvars[:management].WeedRC, gvars[:crop].CCx, gvars[:management].WeedShape)
         setparameter!(gvars[:float_parameters], :fweednos, fweednos)
         ccxcrop_weednosf_stress = round(Int, (100*gvars[:crop].CCx*fweednos + 0.49))/100 # reference for plot with weed
         setparameter!(gvars[:float_parameters], :ccxcrop_weednosf_stress, ccxcrop_weednosf_stress)
         if gvars[:management].FertilityStress > 0
             fweed = 1
-            if (fi > 0) & (gvars[:crop].subkind == :Forage) 
+            if (fi > 0) & (gvars[:crop].subkind == :Forage)
                 cweed = 1
                 if fi > 0.005
                     # calculate the adjusted weed cover
                     gvars[:simulation].RCadj = round(Int, gvars[:management].WeedRC+cweed*(1-fi)*gvars[:crop].CCx*
                                                      (1-gvars[:simulation].EffectStress.RedCCX/100)*gvars[:management].WeedAdj/100)
-                    if (gvars[:simulation].RCadj < (100*(1-fi/(fi+(1-fi)*(gvars[:management].WeedAdj/100))))) 
+                    if (gvars[:simulation].RCadj < (100*(1-fi/(fi+(1-fi)*(gvars[:management].WeedAdj/100)))))
                         gvars[:simulation].RCadj = round(Int, 100*(1-fi/(fi+(1-fi)*(gvars[:management].WeedAdj/100))))
                     end
                     if gvars[:simulation].RCadj > 100
                         gvars[:simulation].RCadj = 98
-                    end 
+                    end
                 else
-                    gvars[:simulation].RCadj = 100 
-                end 
-            end 
+                    gvars[:simulation].RCadj = 100
+                end
+            end
         else
-            if gvars[:crop].subkind == :Forage 
-                fweed, rcadj = cc_multiplier_weed_adjusted(gvars[:management].WeedRC, 
+            if gvars[:crop].subkind == :Forage
+                fweed, rcadj = cc_multiplier_weed_adjusted(gvars[:management].WeedRC,
                                     gvars[:crop].CCx, gvars[:management].WeedShape,
                                     fi, gvars[:simulation].YearSeason,
                                     gvars[:management].WeedAdj, gvars[:crop].subkind)
                 gvars[:simulation].RCadj = rcadj
             else
                 fweed = gvars[:float_parameters][:fweednos]
-            end 
-        end 
+            end
+        end
     else
         setparameter!(gvars[:float_parameters], :fweednos, 1.0)
         fweed = 1
@@ -246,7 +246,7 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
         fi = multiplier_cco_self_thinning(gvars[:simulation].YearSeason, gvars[:crop].YearCCx, gvars[:crop].CCxRoot)
     else
         fi = 1
-    end 
+    end
     ccototal = (fweed*gvars[:crop].CCo*(fi+cweed*(1-fi)*gvars[:management].WeedAdj/100))
     setparameter!(gvars[:float_parameters], :ccototal, ccototal)
 
@@ -261,7 +261,7 @@ function initialize_simulation_run_part1!(outputs, gvars, projectinput::ProjectI
     setparameter!(gvars[:bool_parameters], :noyear, year1==1901) # for output file
 
     return nothing
-end 
+end
 
 """
     logi = check_for_watertable_in_profile(profilecomp::Vector{CompartmentIndividual}, depthgwtmeter)
@@ -273,20 +273,20 @@ function check_for_watertable_in_profile(profilecomp::Vector{CompartmentIndividu
     ztot = 0
     compi = 0
 
-    if depthgwtmeter>=eps() 
+    if depthgwtmeter>=eps()
         # groundwater table is present
         while (!watertableinprofile) & (compi<length(profilecomp))
             compi = compi + 1
             ztot = ztot + profilecomp[compi].Thickness
             zi = ztot - profilecomp[compi].Thickness/2
-            if zi>=depthgwtmeter 
+            if zi>=depthgwtmeter
                 watertableinprofile = true
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     return watertableinprofile
-end 
+end
 
 function check_for_watertable_in_profile(profilecomp::Vector{AbstractParametersContainer}, depthgwtmeter)
     return check_for_watertable_in_profile(CompartmentIndividual[c for c in profilecomp], depthgwtmeter)
@@ -312,11 +312,11 @@ function adjust_for_watertable!(gvars)
             # compartment at or below groundwater table
             compartments[compi].Theta = soil_layers[compartments[compi].Layer].SAT/100
             determine_salt_content!(compartments[compi], soil_layers, simulparam)
-        end 
-    end 
+        end
+    end
 
     return nothing
-end 
+end
 
 """
     get_gwt_set!(gvars, parentdir, daynrin)
@@ -331,7 +331,7 @@ function get_gwt_set!(gvars, parentdir, daynrin)
         groundwater_file = gvars[:string_parameters][:groundwater_file]
     else
         groundwater_file = parentdir * "GroundWater.AqC"
-    end 
+    end
 
     # Get DayNr1Gwt
     open(groundwater_file, "r") do file
@@ -346,13 +346,13 @@ function get_gwt_set!(gvars, parentdir, daynrin)
         # Read first observation
         for i in 1:3
             readline(file)
-        end 
+        end
         splitedline = split(readline(file))
         daydouble = parse(Float64, popfirst!(splitedline))
         zm = parse(Float64, popfirst!(splitedline))
         gwt.EC2 = parse(Float64, popfirst!(splitedline))
         gwt.DNr2 = daynr1gwt + round(Int, daydouble) - 1
-        gwt.Z2 = round(Int, zm * 100) 
+        gwt.Z2 = round(Int, zm * 100)
         if eof(file)
             theend = true
         else
@@ -360,16 +360,16 @@ function get_gwt_set!(gvars, parentdir, daynrin)
         end
 
         # Read next observations
-        if theend 
+        if theend
             # only one observation
-            gwt.DNr1 = simulation.FromDayNr 
+            gwt.DNr1 = simulation.FromDayNr
             gwt.Z1 = gwt.Z2
             gwt.EC1 = gwt.EC2
-            gwt.DNr2 = simulation.ToDayNr 
+            gwt.DNr2 = simulation.ToDayNr
         else
             # defined year
-            if daynr1gwt>365 
-                if daynrin<gwt.DNr2 
+            if daynr1gwt>365
+                if daynrin<gwt.DNr2
                     # DayNrIN before 1st observation
                     gwt.DNr1 = simulation.FromDayNr
                     gwt.Z1 = gwt.Z2
@@ -387,32 +387,32 @@ function get_gwt_set!(gvars, parentdir, daynrin)
                         gwt.EC2 = parse(Float64, popfirst!(splitedline))
                         gwt.DNr2 = daynr1gwt + round(Int, daydouble) - 1
                         gwt.Z2 = round(Int, zm * 100)
-                        if daynrin<gwt.DNr2 
+                        if daynrin<gwt.DNr2
                             theend = true
-                        end 
+                        end
                         if theend | eof(file)
                             loop1 = false
                         end
                     end
-                    if !theend 
+                    if !theend
                         # DayNrIN after last observation
                         gwt.DNr1 = gwt.DNr2
                         gwt.Z1 = gwt.Z2
                         gwt.EC1 = gwt.EC2
                         gwt.DNr2 = simulation.ToDayNr
-                    end 
-                end 
+                    end
+                end
             end # defined year
 
             # undefined year
-            if daynr1gwt<=365 
+            if daynr1gwt<=365
                 dayi, monthi, yearact = determine_date(daynrin)
-                if yearact != 1901 
+                if yearact != 1901
                     # make 1st observation defined
                     dayi, monthi, yeari = determine_date(gwt.DNr2)
                     gwt.DNr2 = determine_day_nr(dayi, monthi, yearact)
-                end 
-                if daynrin<gwt.DNr2 
+                end
+                if daynrin<gwt.DNr2
                     # DayNrIN before 1st observation
                     loop2 = true
                     while loop2
@@ -423,11 +423,11 @@ function get_gwt_set!(gvars, parentdir, daynrin)
                         gwt.DNr1 = daynr1gwt + round(Int, daydouble) - 1
                         dayi, monthi, yeari = determine_date(gwt.DNr1)
                         gwt.DNr1 = determine_day_nr(dayi, monthi, yearact)
-                        gwt.Z1 = round(Int, zm * 100) 
+                        gwt.Z1 = round(Int, zm * 100)
                         if eof(file)
                             loop2 = false
                         end
-                    end 
+                    end
                     gwt.DNr1 = gwt.DNr1 - 365
                 else
                     # save 1st observation
@@ -445,20 +445,20 @@ function get_gwt_set!(gvars, parentdir, daynrin)
                         zm = parse(Float64, popfirst!(splitedline))
                         gwt.EC2 = parse(Float64, popfirst!(splitedline))
                         gwt.DNr2 = daynr1gwt + round(Int, daydouble) - 1
-                        if yearact != 1901 
+                        if yearact != 1901
                             # make observation defined
                             dayi, monthi, yeari = determine_date(gwt.DNr2)
                             gwt.DNr2 = determine_day_nr(dayi, monthi, yearact)
-                        end 
+                        end
                         gwt.Z2 = round(Int, zm * 100)
-                        if daynrin<gwt.DNr2 
+                        if daynrin<gwt.DNr2
                             theend = true
-                        end 
-                        if theend | eof(file) 
+                        end
+                        if theend | eof(file)
                             loop3 = false
                         end
                     end
-                    if !theend 
+                    if !theend
                         # DayNrIN after last observation
                         gwt.DNr1 = gwt.DNr2
                         gwt.Z1 = gwt.Z2
@@ -466,14 +466,14 @@ function get_gwt_set!(gvars, parentdir, daynrin)
                         gwt.DNr2 = dnrini + 365
                         gwt.Z2 = zini
                         gwt.EC2 = ecini
-                    end 
-                end 
+                    end
+                end
             end # undefined year
         end # more than 1 observation
     end
 
     return nothing
-end 
+end
 
 """
     temperature_file_covering_crop_period!(outputs, gvars, crop_firstday, crop_lastday)
@@ -494,28 +494,28 @@ function temperature_file_covering_crop_period!(outputs, gvars, crop_firstday, c
             i = crop_firstday - gvars[:temperature_record].FromDayNr + 1
             tlow = Tmin[i]
             thigh = Tmax[i]
-        
+
         elseif gvars[:temperature_record].Datatype == :Decadely
             get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, crop_firstday,
-                                            (Tmin, Tmax), 
+                                            (Tmin, Tmax),
                                             gvars[:temperature_record])
             i = 1
             while tmin_dataset[1].DayNr != crop_firstday
                 i += 1
             end
-            tlow = tmin_dataset[i].Param 
-            thigh = tmax_dataset[i].Param 
+            tlow = tmin_dataset[i].Param
+            thigh = tmax_dataset[i].Param
 
         elseif gvars[:temperature_record].Datatype == :Monthly
             get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, crop_firstday,
-                                            (Tmin, Tmax), 
+                                            (Tmin, Tmax),
                                             gvars[:temperature_record])
             i = 1
             while tmin_dataset[1].DayNr != crop_firstday
                 i += 1
             end
-            tlow = tmin_dataset[i].Param 
-            thigh = tmax_dataset[i].Param 
+            tlow = tmin_dataset[i].Param
+            thigh = tmax_dataset[i].Param
         end
 
         # we are not creating the TCrop.SIM for now but we use outputs variable
@@ -525,45 +525,45 @@ function temperature_file_covering_crop_period!(outputs, gvars, crop_firstday, c
         for runningday in (crop_firstday+1):crop_lastday
             if gvars[:temperature_record].Datatype == :Daily
                 i += 1
-                if i==length(gvars[:array_parameters][:Tmin]) 
+                if i==length(gvars[:array_parameters][:Tmin])
                     i = 1
-                end 
+                end
                 tlow = Tmin[i]
                 thigh = Tmax[i]
 
             elseif gvars[:temperature_record].Datatype == :Decadely
                 if runningday>tmin_dataset[31].DayNr
                     get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, runningday,
-                                                    (Tmin, Tmax), 
+                                                    (Tmin, Tmax),
                                                     gvars[:temperature_record])
                 end
                 i = 1
                 while tmin_dataset[1].DayNr != runningday
                     i += 1
-                end 
-                tlow = tmin_dataset[i].Param 
-                thigh = tmax_dataset[i].Param 
+                end
+                tlow = tmin_dataset[i].Param
+                thigh = tmax_dataset[i].Param
 
             elseif gvars[:temperature_record].Datatype == :Monthly
                 if runningday>tmin_dataset[31].DayNr
                     get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, runningday,
-                                                     (Tmin, Tmax), 
+                                                     (Tmin, Tmax),
                                                      gvars[:temperature_record])
-                end 
-                i = 1 
+                end
+                i = 1
                 while tmin_dataset[1].DayNr != runningday
                     i += 1
                 end
-                tlow = tmin_dataset[i].Param 
-                thigh = tmax_dataset[i].Param 
+                tlow = tmin_dataset[i].Param
+                thigh = tmax_dataset[i].Param
             end
 
             add_output_in_tcropsim!(outputs, tlow, thigh)
-        end 
+        end
     end
 
     return nothing
-end 
+end
 
 """
     co2forsimulationperiod = co2_for_simulation_period(co2_file, fromdaynr, todaynr)
@@ -574,8 +574,8 @@ function co2_for_simulation_period(co2_file, fromdaynr, todaynr)
     dayi, monthi, fromyi = determine_date(fromdaynr)
     dayi, monthi, toyi = determine_date(todaynr)
 
-    if (fromyi == 1901) | (toyi == 1901) 
-        co2forsimulationperiod = CO2Ref 
+    if (fromyi == 1901) | (toyi == 1901)
+        co2forsimulationperiod = CO2Ref
     elseif isfile(co2_file)
         co2from = undef_double
         co2to = undef_double
@@ -604,17 +604,17 @@ function co2_for_simulation_period(co2_file, fromdaynr, todaynr)
                     if (round(Int, yearb) >= fromyi) | eof(file)
                         loop_1 = false
                     end
-                end 
-                if fromyi > round(Int, yearb) 
+                end
+                if fromyi > round(Int, yearb)
                     co2from = co2b
                 else
                     co2from = co2a + (co2b-co2a)*(fromyi-round(Int, yeara))/(round(Int, yearb)-round(Int, yeara))
-                end 
-            end 
+                end
+            end
             # to year
             co2to = co2from
-            if (toyi > fromyi) & (toyi > round(Int, yeara)) 
-                if round(Int, yearb) >= toyi 
+            if (toyi > fromyi) & (toyi > round(Int, yeara))
+                if round(Int, yearb) >= toyi
                     co2to = co2a + (co2b-co2a)*(toyi-round(Int, yeara))/(round(Int, yearb)-round(Int, yeara))
                 elseif !eof(file)
                     loop_2 = true
@@ -627,22 +627,22 @@ function co2_for_simulation_period(co2_file, fromdaynr, todaynr)
                         if (round(Int, yearb) >= toyi) | eof(file)
                             loop_2 = false
                         end
-                    end 
-                    if toyi > round(Int, yearb) 
+                    end
+                    if toyi > round(Int, yearb)
                         co2to = co2b
                     else
                         co2to = co2a + (co2b-co2a)*(toyi-round(Int, yeara))/(round(Int, yearb)-round(Int, yeara))
-                    end 
-                end 
-            end 
+                    end
+                end
+            end
         end
         co2forsimulationperiod = (co2from+co2to)/2
     else
-        co2forsimulationperiod = CO2Ref 
-    end 
+        co2forsimulationperiod = CO2Ref
+    end
 
     return co2forsimulationperiod
-end 
+end
 
 """
     relationships_for_fertility_and_salt_stress!(outputs, gvars; kwargs...)
@@ -660,10 +660,10 @@ function relationships_for_fertility_and_salt_stress!(outputs, gvars; kwargs...)
         setparameter!(gvars[:float_parameters], :coeffb0, undef_double)
         setparameter!(gvars[:float_parameters], :coeffb1, undef_double)
         setparameter!(gvars[:float_parameters], :coeffb2, undef_double)
-    end 
+    end
 
     # 1.b Soil fertility : FracBiomassPotSF
-    if (abs(gvars[:management].FertilityStress) > eps()) & gvars[:crop].StressResponse.Calibrated 
+    if (abs(gvars[:management].FertilityStress) > eps()) & gvars[:crop].StressResponse.Calibrated
         biolow = 100
         strlow = 0
         strtop = undef_int
@@ -678,15 +678,15 @@ function relationships_for_fertility_and_salt_stress!(outputs, gvars; kwargs...)
                 loopi = false
             end
         end
-        if strlow >= 99.99 
+        if strlow >= 99.99
             strlow = 100
-        end 
-        if abs(strlow-strtop) < 0.001 
+        end
+        if abs(strlow-strtop) < 0.001
             setparameter!(gvars[:float_parameters], :fracbiomasspotsf, biotop/100)
         else
             setparameter!(gvars[:float_parameters], :fracbiomasspotsf, (biotop - (gvars[:management].FertilityStress - strtop)/(strlow - strtop))/100)
-        end 
-    end 
+        end
+    end
 
     # 2. soil salinity (Coeffb0Salt,Coeffb1Salt,Coeffb2Salt : CCx/KsSto - Salt stress)
     if gvars[:simulation].SalinityConsidered == true
@@ -698,207 +698,207 @@ function relationships_for_fertility_and_salt_stress!(outputs, gvars; kwargs...)
     end
 
     return nothing
-end 
+end
 
 """
-    sumkcpot = seasonal_sum_of_kcpot(outputs, thedaystoccini, thegddaystoccini, l0, l12, 
-                                     l123, l1234, gddl0, gddl12, gddl123, 
-                                     gddl1234, cco, ccx, cgc, gddcgc, cdc, 
-                                     gddcdc, kctop, kcdeclageing, 
-                                     cceffectprocent, tbase, tupper, tdaymin, 
+    sumkcpot = seasonal_sum_of_kcpot(outputs, thedaystoccini, thegddaystoccini, l0, l12,
+                                     l123, l1234, gddl0, gddl12, gddl123,
+                                     gddl1234, cco, ccx, cgc, gddcgc, cdc,
+                                     gddcdc, kctop, kcdeclageing,
+                                     cceffectprocent, tbase, tupper, tdaymin,
                                      tdaymax, gdtransplow, co2i, themodecycle,
                                      simulation, simulparam, referenceclimate)
 
 global.f90:SeasonalSumOfKcPot:5332
 note that we must do simulation.DelayedDays = 0 before calling this function
 """
-function seasonal_sum_of_kcpot(outputs, thedaystoccini, thegddaystoccini, l0, l12, 
-                                     l123, l1234, gddl0, gddl12, gddl123, 
-                                     gddl1234, cco, ccx, cgc, gddcgc, cdc, 
-                                     gddcdc, kctop, kcdeclageing, 
-                                     cceffectprocent, tbase, tupper, tdaymin, 
+function seasonal_sum_of_kcpot(outputs, thedaystoccini, thegddaystoccini, l0, l12,
+                                     l123, l1234, gddl0, gddl12, gddl123,
+                                     gddl1234, cco, ccx, cgc, gddcgc, cdc,
+                                     gddcdc, kctop, kcdeclageing,
+                                     cceffectprocent, tbase, tupper, tdaymin,
                                      tdaymax, gdtransplow, co2i, themodecycle,
                                      simulation, simulparam, referenceclimate)
     etostandard = 5
 
     # 1. Open Temperature file
     if referenceclimate
-        loggi = (length(outputs[:tcropreferencesim][:tlow]) > 0) 
+        loggi = (length(outputs[:tcropreferencesim][:tlow]) > 0)
     else
-        loggi = (length(outputs[:tcropsim][:tlow]) > 0) 
+        loggi = (length(outputs[:tcropsim][:tlow]) > 0)
     end
 
     # 2. Initialise global settings
     # required for CalculateETpot
     # simulation.DelayedDays = 0   note that this should do before calling this function
     sumkcpot = 0
-    sumgddforplot = undef_int 
+    sumgddforplot = undef_int
     sumgdd = undef_int
     sumgddfromday1 = 0
     growthon = false
     gddtadj = undef_int
-    dayfraction = undef_int 
-    gddayfraction = undef_int 
+    dayfraction = undef_int
+    gddayfraction = undef_int
     # 2.bis Initialise 1st day
-    if thedaystoccini != 0 
+    if thedaystoccini != 0
         # regrowth
-        if thedaystoccini == undef_int 
+        if thedaystoccini == undef_int
             # ccx on 1st day
             tadj = l12 - l0
-            if themodecycle == :GDDays 
+            if themodecycle == :GDDays
                 gddtadj = gddl12 - gddl0
                 sumgdd = gddl12
-            end 
+            end
             ccinitial = ccx
         else
             # cc on 1st day is < ccx
             tadj = thedaystoccini
             daycc = tadj + l0
-            if themodecycle == :GDDays 
+            if themodecycle == :GDDays
                 gddtadj = thegddaystoccini
                 sumgdd = gddl0 + thegddaystoccini
                 sumgddforplot = sumgdd
-            end 
-            ccinitial = canopy_cover_no_stress_sf(daycc, l0, l123, l1234, gddl0, 
-                                              gddl123, gddl1234, cco, ccx, 
-                                              cgc, cdc, gddcgc, gddcdc, 
-                                              sumgddforplot, themodecycle, 
+            end
+            ccinitial = canopy_cover_no_stress_sf(daycc, l0, l123, l1234, gddl0,
+                                              gddl123, gddl1234, cco, ccx,
+                                              cgc, cdc, gddcgc, gddcdc,
+                                              sumgddforplot, themodecycle,
                                               0, 0, simulation)
-        end 
+        end
         # Time reduction for days between L12 and L123
         dayfraction = (l123-l12)/(tadj + l0 + (l123-l12))
-        if themodecycle == :GDDays 
+        if themodecycle == :GDDays
             gddayfraction = (gddl123-gddl12)/(gddtadj + gddl0 + (gddl123-gddl12))
-        end 
+        end
     else
         # sowing or transplanting
         tadj = 0
-        if themodecycle == :GDDays 
+        if themodecycle == :GDDays
             gddtadj = 0
             sumgdd = 0
-        end 
+        end
         ccinitial = cco
-    end 
+    end
 
     # 3. Calculate Sum
     for dayi in 1:l1234
         # 3.1 calculate growing degrees for the day
-        if loggi 
+        if loggi
             if referenceclimate
                 aux_dayi = mod1(dayi, length(outputs[:tcropreferencesim][:tlow]))
-                tndayi, txdayi = read_output_from_tcropreferencesim(outputs, aux_dayi) 
+                tndayi, txdayi = read_output_from_tcropreferencesim(outputs, aux_dayi)
             else
-                tndayi, txdayi = read_output_from_tcropsim(outputs, dayi) 
+                tndayi, txdayi = read_output_from_tcropsim(outputs, dayi)
             end
             gddi = degrees_day(tbase, tupper, tndayi, txdayi, simulparam.GDDMethod)
         else
             # OJO this includes temperature_file = "None" and "External" because we never set TminRun
             # to use GetTminRun like in global.f90:SeasonalSumOfKcPot:5447
             gddi = degrees_day(tbase, tupper, tdaymin, tdaymax, simulparam.GDDMethod)
-        end 
-        if themodecycle == :GDDays 
+        end
+        if themodecycle == :GDDays
             sumgdd = sumgdd + gddi
             sumgddfromday1 = sumgddfromday1 + gddi
-        end 
+        end
 
         # 3.2 calculate CCi
-        if growthon == false 
+        if growthon == false
             # not yet canopy development
             cci = 0
             daycc = dayi
-            if thedaystoccini != 0 
+            if thedaystoccini != 0
                 # regrowth on 1st day
                 cci = ccinitial
                 growthon = true
             else
                 # wait for day of germination or recover of transplant
-                if themodecycle == :CalendarDays 
-                    if dayi == (l0+1) 
+                if themodecycle == :CalendarDays
+                    if dayi == (l0+1)
                         cci = ccinitial
                         growthon = true
-                    end 
+                    end
                 else
-                    if sumgdd > gddl0 
+                    if sumgdd > gddl0
                         cci = ccinitial
                         growthon = true
-                    end 
-                end 
-            end 
+                    end
+                end
+            end
         else
-            if thedaystoccini == 0 
+            if thedaystoccini == 0
                 daycc = dayi
             else
                 daycc = dayi + tadj + l0 # adjusted time scale
-                if daycc > l1234 
+                if daycc > l1234
                     daycc = l1234 # special case where l123 > l1234
-                end 
-                if daycc > l12 
-                    if dayi <= l123 
+                end
+                if daycc > l12
+                    if dayi <= l123
                         daycc = l12 + round(Int, dayfraction * (dayi+tadj+l0 - l12)) # slowdown
                     else
                         daycc = dayi # switch time scale
-                    end 
-                end 
-            end 
-            if themodecycle == :GDDays 
-                if thegddaystoccini == 0 
+                    end
+                end
+            end
+            if themodecycle == :GDDays
+                if thegddaystoccini == 0
                     sumgddforplot = sumgddfromday1
                 else
                     sumgddforplot = sumgdd
-                    if sumgddforplot > gddl1234 
+                    if sumgddforplot > gddl1234
                         sumgddforplot = gddl1234 # special case
                                                  # where L123 > L1234
-                    end 
-                    if sumgddforplot > gddl12 
-                        if sumgddfromday1 <= gddl123 
+                    end
+                    if sumgddforplot > gddl12
+                        if sumgddfromday1 <= gddl123
                             sumgddforplot = gddl12 + round(Int, gddayfraction * (sumgddfromday1+gddtadj+gddl0-gddl12)) # slow down
                         else
                             sumgddforplot = sumgddfromday1 # switch time scale
-                        end 
-                    end 
-                end 
-            end 
-            cci = canopy_cover_no_stress_sf(daycc, l0, l123, l1234, gddl0, 
-                                        gddl123, gddl1234, cco, ccx, 
-                                        cgc, cdc, gddcgc, gddcdc, 
-                                        sumgddforplot, themodecycle, 
+                        end
+                    end
+                end
+            end
+            cci = canopy_cover_no_stress_sf(daycc, l0, l123, l1234, gddl0,
+                                        gddl123, gddl1234, cco, ccx,
+                                        cgc, cdc, gddcgc, gddcdc,
+                                        sumgddforplot, themodecycle,
                                         0, 0, simulation)
         end
 
         # 3.3 calculate CCxWithered
         ccxwitheredforb = cci
-        if dayi >= l12 
+        if dayi >= l12
             ccxwitheredforb = ccx
-        end 
+        end
 
         # 3.4 Calculate Tpot + Adjust for Low temperature
         # (no transpiration)
         if cci > 0.0001
-            tpotforb, epottotforb = calculate_etpot(daycc, l0, l12, l123, l1234, 0, cci, 
-                           etostandard, kctop, 
-                           kcdeclageing, ccx, ccxwitheredforb, 
-                           cceffectprocent, co2i, 
-                           gddi, gdtransplow, simulation, simulparam) 
+            tpotforb, epottotforb = calculate_etpot(daycc, l0, l12, l123, l1234, 0, cci,
+                           etostandard, kctop,
+                           kcdeclageing, ccx, ccxwitheredforb,
+                           cceffectprocent, co2i,
+                           gddi, gdtransplow, simulation, simulparam)
         else
             tpotforb = 0
-        end 
+        end
 
         # 3.5 Sum of Sum Of KcPot
         sumkcpot = sumkcpot + (tpotforb/etostandard)
-    end 
+    end
 
     # 6. final sum
     return sumkcpot
-end 
+end
 
 """
-    canopycovernostresssf = canopy_cover_no_stress_sf(dap, l0, l123, 
+    canopycovernostresssf = canopy_cover_no_stress_sf(dap, l0, l123,
        lmaturity, gddl0, gddl123, gddlmaturity, cco, ccx,
        cgc, cdc, gddcgc, gddcdc, sumgdd, typedays, sfredcgc, sfredccx, simulation)
 
 global.f90:CanopyCoverNoStressSF:1317
 """
-function canopy_cover_no_stress_sf(dap, l0, l123, 
+function canopy_cover_no_stress_sf(dap, l0, l123,
        lmaturity, gddl0, gddl123, gddlmaturity, cco, ccx,
        cgc, cdc, gddcgc, gddcdc, sumgdd, typedays, sfredcgc, sfredccx, simulation)
     if typedays == :GDDays
@@ -907,9 +907,9 @@ function canopy_cover_no_stress_sf(dap, l0, l123,
     else
         canopycovernostresssf = canopy_cover_no_stress_days_sf(dap, l0, l123,
             lmaturity, cco, ccx, cgc, cdc, sfredcgc, sfredccx, simulation)
-    end 
+    end
     return canopycovernostresssf
-end 
+end
 
 
 """
@@ -925,7 +925,7 @@ function canopy_cover_no_stress_days_sf(dap, l0, l123,
     t = dap - simulation.DelayedDays
     # CC refers to canopy cover at the end of the day
 
-    if (t >= 1) & (t <= lmaturity) & (cco > eps()) 
+    if (t >= 1) & (t <= lmaturity) & (cco > eps())
         if t <= l0  # before germination or recovering of transplant
             cc = 0
         else
@@ -934,74 +934,74 @@ function canopy_cover_no_stress_days_sf(dap, l0, l123,
                               ((1-sfredccx/100)*ccx))
             else
                # Late-season stage  (t <= LMaturity)
-                if ccx < 0.001 
+                if ccx < 0.001
                     cc = 0
                 else
-                    ccxadj = cc_at_time((l123-l0), cco, 
+                    ccxadj = cc_at_time((l123-l0), cco,
                               ((1-sfredcgc/100)*cgc),
                               ((1-sfredccx/100)*ccx))
                     cdcadj = cdc*(ccxadj+2.29)/(ccx+2.29)
-                    if ccxadj < 0.001 
+                    if ccxadj < 0.001
                         cc = 0
                     else
                         cc = ccxadj * (1 - 0.05 *
                              (exp((t-l123)*3.33*cdcadj/(ccxadj+2.29))-1))
-                    end 
-                end 
-            end 
-        end 
+                    end
+                end
+            end
+        end
     end
     if cc > 1
         cc = 1
     elseif cc < eps()
         cc = 0
-    end 
+    end
 
     return cc
-end 
+end
 
 """
-    cc = canopy_cover_no_stress_gddays_sf(gddl0, gddl123, gddlmaturity, sumgdd, 
+    cc = canopy_cover_no_stress_gddays_sf(gddl0, gddl123, gddlmaturity, sumgdd,
         cco, ccx, gddcgc, gddcdc, sfredcgc, sfredccx)
 
 global.f90:CanopyCoverNoStressGDDaysSF2687
 """
-function canopy_cover_no_stress_gddays_sf(gddl0, gddl123, gddlmaturity, sumgdd, 
+function canopy_cover_no_stress_gddays_sf(gddl0, gddl123, gddlmaturity, sumgdd,
         cco, ccx, gddcgc, gddcdc, sfredcgc, sfredccx)
     # sumgdd refers to the end of the day and delayed days are not considered
     cc = 0
-    if (sumgdd > 0) & (round(Int, sumgdd) <= gddlmaturity) & (cco > 0) 
+    if (sumgdd > 0) & (round(Int, sumgdd) <= gddlmaturity) & (cco > 0)
         if sumgdd <= gddl0  # before germination or recovering of transplant
             cc = 0
         else
             if sumgdd < gddl123  # canopy development and mid-season stage
-                cc = cc_at_gdd((sumgdd-gddl0), cco, ((1-sfredcgc/100)*gddcgc), 
+                cc = cc_at_gdd((sumgdd-gddl0), cco, ((1-sfredcgc/100)*gddcgc),
                   ((1-sfredccx/100)*ccx))
             else
                 # late-season stage  (sumgdd <= gddlmaturity)
                 if ccx < 0.001
                     cc = 0
                 else
-                    ccxadj = cc_at_gdd((gddl123-gddl0), cco, ((1-sfredcgc/100)*gddcgc), 
+                    ccxadj = cc_at_gdd((gddl123-gddl0), cco, ((1-sfredcgc/100)*gddcgc),
                       ((1-sfredccx/100)*ccx))
                     gddcdcadj = gddcdc*(ccxadj+2.29)/(ccx+2.29)
-                    if (ccxadj < 0.001) 
+                    if (ccxadj < 0.001)
                         cc = 0
                     else
                         cc = ccxadj * (1 - 0.05*(exp((sumgdd-gddl123)*3.33*gddcdcadj/
                           (ccxadj+2.29))-1))
-                    end 
-                end 
-            end 
-        end 
-    end 
+                    end
+                end
+            end
+        end
+    end
     if cc > 1
         cc = 1
     elseif cc < 0
         cc = 0
-    end 
+    end
     return cc
-end 
+end
 
 
 """
@@ -1011,107 +1011,107 @@ global.f90:CCatGDD:2671
 """
 function cc_at_gdd(gddi, ccoin, gddcgcin, ccxin)
     cci = ccoin * exp(gddcgcin * gddi)
-    if cci > ccxin/2 
+    if cci > ccxin/2
         cci = ccxin - 0.25 * (ccxin/ccoin) * ccxin * exp(-gddcgcin*gddi)
-    end 
+    end
     return cci
 end
 
 """
-   tpotval, epotval = calculate_etpot(dap, l0, l12, l123, lharvest, daylastcut, cci, 
-                          etoval, kcval, kcdeclineval, ccx, ccxwithered, 
-                          cceffectprocent, co2i, gddayi, tempgdtransplow, 
+   tpotval, epotval = calculate_etpot(dap, l0, l12, l123, lharvest, daylastcut, cci,
+                          etoval, kcval, kcdeclineval, ccx, ccxwithered,
+                          cceffectprocent, co2i, gddayi, tempgdtransplow,
                           simulation, simulparam)
 
 global.f90:CalculateETpot:7925
 """
-function calculate_etpot(dap, l0, l12, l123, lharvest, daylastcut, cci, 
-                          etoval, kcval, kcdeclineval, ccx, ccxwithered, 
-                          cceffectprocent, co2i, gddayi, tempgdtransplow, 
+function calculate_etpot(dap, l0, l12, l123, lharvest, daylastcut, cci,
+                          etoval, kcval, kcdeclineval, ccx, ccxwithered,
+                          cceffectprocent, co2i, gddayi, tempgdtransplow,
                           simulation, simulparam)
     # CalculateETpot
     virtualday = dap - simulation.DelayedDays
-    if ((virtualday < l0) & (round(Int, 100*cci) == 0)) | (virtualday > lharvest) 
+    if ((virtualday < l0) & (round(Int, 100*cci) == 0)) | (virtualday > lharvest)
         # To handlle Forage crops: Round(100*CCi) = 0
         tpotval = 0
         epotval = simulparam.KcWetBare*etoval
     else
         # Correction for micro-advection
         cciadjusted = 1.72*cci - 1*(cci*cci) + 0.30*(cci*cci*cci)
-        if cciadjusted < eps() 
+        if cciadjusted < eps()
             cciadjusted = 0
-        elseif cciadjusted > 1 
+        elseif cciadjusted > 1
             cciadjusted = 1
-        end 
+        end
 
         # Correction for ageing effects - is a function of calendar days
-        if (virtualday-daylastcut) > (l12+5) 
+        if (virtualday-daylastcut) > (l12+5)
             kcval_local = kcval - (virtualday-daylastcut-(l12+5)) * (kcdeclineval/100)*ccxwithered
         else
             kcval_local = kcval
-        end 
+        end
 
         # Correction for elevated atmospheric CO2 concentration
-        if co2i > 369.41 
+        if co2i > 369.41
             kcval_local = kcval_local * (1 - 0.05 * (co2i-369.41)/(550-369.41))
-        end 
+        end
 
         # Correction for Air temperature stress
-        if (cciadjusted <= ac_zero_threshold) | (round(Int, gddayi) < 0) 
+        if (cciadjusted <= ac_zero_threshold) | (round(Int, gddayi) < 0)
             kstrcold = 1
         else
             kstrcold = ks_temperature(0, tempgdtransplow, gddayi)
-        end 
+        end
 
         # First estimate of Epot and Tpot
         tpotval = cciadjusted * kstrcold * kcval_local * etoval
         epotval = simulparam.KcWetBare * (1 - cciadjusted) * etoval
 
         # Maximum Epot with withered canopy as a result of (early) senescence
-        epotmax = simulparam.KcWetBare * etoval * 
+        epotmax = simulparam.KcWetBare * etoval *
                         (1 - ccxwithered * cceffectprocent/100)
 
         # Correction Epot for dying crop in late-season stage
-        if (virtualday > l123) & (ccx > eps()) 
-            if cci > (ccx/2) 
+        if (virtualday > l123) & (ccx > eps())
+            if cci > (ccx/2)
                 # not yet full effect
-                if cci > ccx 
+                if cci > ccx
                     multiplier = 0  # no effect
                 else
                     multiplier = (ccx-cci)/(ccx/2)
-                end 
+                end
             else
                 multiplier = 1 # full effect
-            end 
+            end
             epotval = epotval * (1 - ccx * (cceffectprocent/100) * multiplier)
             epotmin = simulparam.KcWetBare * (1 - 1.72*ccx + 1*(ccx*ccx) - 0.30*(ccx*ccx*ccx)) * etoval
-            if epotmin < eps() 
+            if epotmin < eps()
                 epotmin = 0
-            end 
-            if epotval < epotmin 
+            end
+            if epotval < epotmin
                 epotval = epotmin
-            end 
-            if epotval > epotmax 
+            end
+            if epotval > epotmax
                 epotval = epotmax
-            end 
-        end 
+            end
+        end
 
         # Correction for canopy senescence before late-season stage
-        if simulation.EvapLimitON 
-            if epotval > epotmax 
+        if simulation.EvapLimitON
+            if epotval > epotmax
                 epotval = epotmax
-            end 
-        end 
+            end
+        end
 
         # Correction for drop in photosynthetic capacity of a dying green canopy
-        if cci < ccxwithered 
-            if (ccxwithered > 0.01) & (cci > 0.001) 
+        if cci < ccxwithered
+            if (ccxwithered > 0.01) & (cci > 0.001)
                 tpotval = tpotval * exp(simulparam.ExpFsen * log(cci/ccxwithered))
-            end 
-        end 
-    end 
+            end
+        end
+    end
     return tpotval, epotval
-end 
+end
 
 """
     m = ks_temperature(t0, t1, tin)
@@ -1120,30 +1120,30 @@ global.f90:KsTemperature:1998
 """
 function ks_temperature(t0, t1, tin)
     m = 1 # no correction applied (to and/or t1 is undefined, or t0=t1)
-    if (round(Int, t0) != undef_int) & 
-         (round(Int, t1) != undef_int) & (abs(t0-t1)>epsilon) 
-        if t0 < t1 
+    if (round(Int, t0) != undef_int) &
+         (round(Int, t1) != undef_int) & (abs(t0-t1)>epsilon)
+        if t0 < t1
             a =  1  # cold stress
         else
             a = -1 # heat stress
-        end 
-        if (a*tin > a*t0) & (a*tin < a*t1) 
+        end
+        if (a*tin > a*t0) & (a*tin < a*t1)
             # within range for correction
             m = getks(t0, t1, tin)
-            if m < 0 
+            if m < 0
                 m = 0
-            elseif m > 1 
+            elseif m > 1
                 m = 1
-            end 
+            end
         else
-            if a*tin <= a*t0 
+            if a*tin <= a*t0
                 m = 0
-            end 
-            if a*tin >= a*t1 
+            end
+            if a*tin >= a*t1
                 m = 1
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     return  m
 end
@@ -1175,7 +1175,7 @@ global.f90:HarvestIndexGrowthCoefficient:1877
 function harvest_index_growth_coefficient(himax, dhidt)
     hio = 1
 
-    if himax > hio 
+    if himax > hio
         t = himax/dhidt
         higc = 0.001
         higc = higc + 0.001
@@ -1183,14 +1183,14 @@ function harvest_index_growth_coefficient(himax, dhidt)
         while (hivar <= (0.98*himax))
             higc = higc + 0.001
             hivar = (hio*himax)/(hio+(himax-hio)*exp(-higc*t))
-        end 
+        end
 
-        if hivar >= himax 
+        if hivar >= himax
             higc = higc - 0.001
-        end 
+        end
     else
         higc = undef_int
-    end 
+    end
     return higc
 end
 
@@ -1204,26 +1204,26 @@ function get_day_switch_to_linear(himax, dhidt, higc)
     tmax = round(Int, himax/dhidt)
     ti = 0
     him1 = hio
-    if tmax > 0 
+    if tmax > 0
         loopi = true
         while loopi
             ti = ti + 1
             hii = (hio*himax)/ (hio+(himax-hio)*exp(-higc*ti))
             hifinal = hii + (tmax - ti)*(hii-him1)
             him1 = hii
-            if (hifinal > himax) | (ti >= tmax)  
+            if (hifinal > himax) | (ti >= tmax)
                 loopi = false
             end
-        end 
+        end
         tswitch = ti - 1
     else
         tswitch = 0
-    end 
-    if tswitch > 0 
+    end
+    if tswitch > 0
         hii = (hio*himax)/ (hio+(himax-hio)*exp(-higc*tswitch))
     else
         hii = 0
-    end 
+    end
     higclinear = (himax-hii)/(tmax-tswitch)
 
     return tswitch, higclinear
@@ -1231,14 +1231,14 @@ end
 
 """
     sumbnor = bnormalized(outputs, thedaystoccini, thegddaystoccini,
-            l0, l12, l12sf, l123, l1234, lflor, 
-            gddl0, gddl12, gddl12sf, gddl123, gddl1234, 
-            wpyield, daysyieldformation, tswitch, cco, ccx, 
-            cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing, 
-            cceffectprocent, wpbio, theco2, tbase, tupper, 
-            tdaymin, tdaymax, gdtransplow, ratdgdd, sumkctop, 
-            stressinpercent, strresredcgc, strresredccx, strresredwp, 
-            strresredkssto, weedstress, deltaweedstress, strrescdecline, 
+            l0, l12, l12sf, l123, l1234, lflor,
+            gddl0, gddl12, gddl12sf, gddl123, gddl1234,
+            wpyield, daysyieldformation, tswitch, cco, ccx,
+            cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing,
+            cceffectprocent, wpbio, theco2, tbase, tupper,
+            tdaymin, tdaymax, gdtransplow, ratdgdd, sumkctop,
+            stressinpercent, strresredcgc, strresredccx, strresredwp,
+            strresredkssto, weedstress, deltaweedstress, strrescdecline,
             shapefweed, themodecycle, fertilitystresson,
             simulation, simulparam, management, crop, referenceclimate)
 
@@ -1246,27 +1246,27 @@ tempprocessing.f90:Bnormalized:2726
 note that we must do simulation.DelayedDays = 0 before calling this function
 """
 function bnormalized(outputs, thedaystoccini, thegddaystoccini,
-            l0, l12, l12sf, l123, l1234, lflor, 
-            gddl0, gddl12, gddl12sf, gddl123, gddl1234, 
-            wpyield, daysyieldformation, tswitch, cco, ccx, 
-            cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing, 
-            cceffectprocent, wpbio, theco2, tbase, tupper, 
-            tdaymin, tdaymax, gdtransplow, ratdgdd, sumkctop, 
-            stressinpercent, strresredcgc, strresredccx, strresredwp, 
-            strresredkssto, weedstress, deltaweedstress, strrescdecline, 
+            l0, l12, l12sf, l123, l1234, lflor,
+            gddl0, gddl12, gddl12sf, gddl123, gddl1234,
+            wpyield, daysyieldformation, tswitch, cco, ccx,
+            cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing,
+            cceffectprocent, wpbio, theco2, tbase, tupper,
+            tdaymin, tdaymax, gdtransplow, ratdgdd, sumkctop,
+            stressinpercent, strresredcgc, strresredccx, strresredwp,
+            strresredkssto, weedstress, deltaweedstress, strrescdecline,
             shapefweed, themodecycle, fertilitystresson,
             simulation, simulparam, management, crop, referenceclimate)
-    
+
     etostandard = 5
     k = 2
 
     # 1. Adjustment for weed infestation
-    if weedstress > 0 
+    if weedstress > 0
         if stressinpercent > 0  # soil fertility stress
             fweed = 1  # no expansion of canopy cover possible
         else
             fweed = cc_multiplier_weed(weedstress, ccx, shapefweed)
-        end 
+        end
         ccoadj = cco*fweed
         ccxadj = ccx*fweed
         cdcadj = cdc*(fweed*ccx + 2.29)/(ccx + 2.29)
@@ -1276,13 +1276,13 @@ function bnormalized(outputs, thedaystoccini, thegddaystoccini,
         ccxadj = ccx
         cdcadj = cdc
         gddcdcadj = gddcdc
-    end 
+    end
 
     # 2. Open Temperature file
     if referenceclimate
-        loggi = (length(outputs[:tcropreferencesim][:tlow]) > 0) 
+        loggi = (length(outputs[:tcropreferencesim][:tlow]) > 0)
     else
-        loggi = (length(outputs[:tcropsim][:tlow]) > 0) 
+        loggi = (length(outputs[:tcropsim][:tlow]) > 0)
     end
 
     # 3. Initialize
@@ -1301,145 +1301,145 @@ function bnormalized(outputs, thedaystoccini, thegddaystoccini,
     ccxwitheredforb = 0
 
     # 4. Initialise 1st day
-    if thedaystoccini != 0 
+    if thedaystoccini != 0
         # regrowth which starts on 1st day
         growthon = true
-        if thedaystoccini == undef_int 
+        if thedaystoccini == undef_int
             # ccx on 1st day
             tadj = l12 - l0
-            if themodecycle == :gddays 
+            if themodecycle == :gddays
                 gddtadj = gddl12 - gddl0
                 sumgdd = gddl12
-            end 
+            end
             ccinitial = ccxadj * (1-strresredccx/100)
         else
             # cc on 1st day is < ccx
             tadj = thedaystoccini
             daycc = tadj + l0
-            if themodecycle == :GDDays 
+            if themodecycle == :GDDays
                 gddtadj = thegddaystoccini
                 sumgdd = gddl0 + thegddaystoccini
                 sumgddforplot = sumgdd
-            end 
+            end
             ccinitial = canopy_cover_no_stress_sf(daycc, l0, l123, l1234,
                             gddl0, gddl123, gddl1234, ccoadj, ccxadj, cgc, cdcadj,
-                            gddcgc, gddcdcadj, sumgddforplot, themodecycle, 
+                            gddcgc, gddcdcadj, sumgddforplot, themodecycle,
                             strresredcgc, strresredccx, simulation)
-        end 
+        end
         # Time reduction for days between L12 and L123
         dayfraction = (l123-l12) * 1/(tadj + l0 + (l123-l12))
-        if themodecycle == :GDDays 
+        if themodecycle == :GDDays
             gddayfraction = (gddl123-gddl12) * 1/(gddtadj + gddl0 + (gddl123-gddl12))
-        end 
+        end
     else
         # growth starts after germination/recover
         tadj = 0
-        if themodecycle == :GDDays 
+        if themodecycle == :GDDays
             gddtadj = 0
             sumgdd = 0
-        end 
+        end
         ccinitial = ccoadj
-    end 
+    end
 
     # 5. Calculate Bnormalized
     for dayi in 1:l1234
         # 5.1 growing degrees for dayi
-        if loggi 
+        if loggi
             if referenceclimate
                 aux_dayi = mod1(dayi, length(outputs[:tcropreferencesim][:tlow]))
-                tndayi, txdayi = read_output_from_tcropreferencesim(outputs, aux_dayi) 
+                tndayi, txdayi = read_output_from_tcropreferencesim(outputs, aux_dayi)
             else
-                tndayi, txdayi = read_output_from_tcropsim(outputs, dayi) 
+                tndayi, txdayi = read_output_from_tcropsim(outputs, dayi)
             end
             gddi = degrees_day(tbase, tupper, tndayi, txdayi, simulparam.GDDMethod)
         else
             # OJO this includes temperature_file = "None" and "External" because we never set TminRun
             # to use GetTminRun like in global.f90:SeasonalSumOfKcPot:5447
             gddi = degrees_day(tbase, tupper, tdaymin, tdaymax, simulparam.GDDMethod)
-        end 
-        if themodecycle == :GDDays 
+        end
+        if themodecycle == :GDDays
             sumgdd = sumgdd + gddi
             sumgddfromday1 = sumgddfromday1 + gddi
-        end 
+        end
 
         # 5.2 green Canopy Cover (CC)
         daycc = dayi
-        if growthon == false 
+        if growthon == false
             # not yet canopy development
             cci = 0
-            if thedaystoccini != 0 
+            if thedaystoccini != 0
                 # regrowth
                 cci = ccinitial
                 growthon = true
             else
                 # sowing or transplanting
-                if themodecycle == :CalendarDays 
-                    if dayi == (l0+1) 
+                if themodecycle == :CalendarDays
+                    if dayi == (l0+1)
                         cci = ccinitial
                         growthon = true
-                    end 
+                    end
                 else
-                    if sumgdd > gddl0 
+                    if sumgdd > gddl0
                         cci = ccinitial
                         growthon = true
-                    end 
-                end 
-            end 
+                    end
+                end
+            end
         else
-            if thedaystoccini == 0 
+            if thedaystoccini == 0
                 daycc = dayi
             else
                 daycc = dayi + tadj + l0 # adjusted time scale
-                if daycc > l1234 
+                if daycc > l1234
                     daycc = l1234 # special case where l123 > l1234
-                end 
-                if daycc > l12 
-                    if dayi <= l123 
+                end
+                if daycc > l12
+                    if dayi <= l123
                          daycc = l12 + round(Int, dayfraction * (dayi+tadj+l0 - l12)) # slow down
                     else
                         daycc = dayi # switch time scale
-                    end 
-                end 
-            end 
+                    end
+                end
+            end
 
-            if themodecycle == :GDDays 
-                if thegddaystoccini == 0 
+            if themodecycle == :GDDays
+                if thegddaystoccini == 0
                     sumgddforplot = sumgddfromday1
                 else
                     sumgddforplot = sumgdd
-                    if sumgddforplot > gddl1234 
+                    if sumgddforplot > gddl1234
                         sumgddforplot = gddl1234
                         # special case where l123 > l1234
-                    end 
-                    if sumgddforplot > gddl12 
-                        if sumgddfromday1 <= gddl123 
+                    end
+                    if sumgddforplot > gddl12
+                        if sumgddfromday1 <= gddl123
                             sumgddforplot = gddl12 + round(Int, gddayfraction * (sumgddfromday1+gddtadj+gddl0-gddl12)) # slow down
                         else
                             sumgddforplot = sumgddfromday1 # switch time scale
-                        end 
-                    end 
-                end 
+                        end
+                    end
+                end
             end
             cci = cci_no_water_stress_sf(daycc, l0, l12sf, l123, l1234,
                         gddl0, gddl12sf, gddl123, gddl1234,
-                        ccoadj, ccxadj, cgc, gddcgc, cdcadj, gddcdcadj, 
+                        ccoadj, ccxadj, cgc, gddcgc, cdcadj, gddcdcadj,
                         sumgddforplot, ratdgdd,
                         strresredcgc, strresredccx, strrescdecline,
                         themodecycle, simulation)
-        end 
+        end
 
 
-        if cci > ccxwitheredforb 
+        if cci > ccxwitheredforb
             ccxwitheredforb = cci
         end
-        if daycc >= l12sf 
+        if daycc >= l12sf
             ccxwitheredforb = ccxadj*(1-strresredccx/100)
-        end 
+        end
         ccw = cci
 
-        if cci > 0.0001 
+        if cci > 0.0001
             # 5.3 potential transpiration of total canopy cover (crop and weed)
-            tpotforb, epottotforb =  calculate_etpot(daycc, l0, l12, l123, l1234, 0, cci, 
+            tpotforb, epottotforb =  calculate_etpot(daycc, l0, l12, l123, l1234, 0, cci,
                         etostandard, kctop, kcdeclageing,
                         ccxadj, ccxwitheredforb, cceffectprocent, theco2,
                         gddi, gdtransplow, simulation, simulparam)
@@ -1448,81 +1448,81 @@ function bnormalized(outputs, thedaystoccini, thegddaystoccini,
             sumkci = sumkci + (tpotforb/etostandard)
 
             # 5.5 potential transpiration of crop canopy cover (without weed)
-            if weedstress > 0 
+            if weedstress > 0
                 # green canopy cover of the crop (CCw) in weed-infested field
                 # (CCi is CC of crop and weeds)
                 fccx = 1 # only for non perennials (no self-thinning)
-                if deltaweedstress != 0 
+                if deltaweedstress != 0
                     deltaweedstress_local = deltaweedstress
                     weedcorrection, deltaweedstress_local = get_weed_rc(daycc, sumgddforplot, fccx,
                         weedstress, management.WeedAdj,
-                        deltaweedstress_local, l12sf, l123, 
+                        deltaweedstress_local, l12sf, l123,
                         gddl12sf, gddl123, themodecycle)
                 else
                     weedcorrection = weedstress
-                end 
+                end
                 ccw = cci * (1 - weedcorrection/100)
                 # correction for micro-advection
                 cctotstar = 1.72*cci - 1*(cci*cci) + 0.30*(cci*cci*cci)
                 if cctotstar < 0
                     cctotstar = 0
-                end 
-                if cctotstar > 1 
+                end
+                if cctotstar > 1
                     cctotstar = 1
-                end 
-                if ccw > 0.0001 
+                end
+                if ccw > 0.0001
                     ccwstar = ccw + (cctotstar - cci)
                 else
                     ccwstar = 0
-                end 
+                end
                 # crop transpiration in weed-infested field
-                if cctotstar <= 0.0001 
+                if cctotstar <= 0.0001
                     tpotforb = 0
                 else
                     tpotforb = tpotforb * (ccwstar/cctotstar)
-                end 
-            end 
+                end
+            end
         else
             tpotforb = 0
-        end 
+        end
 
         # 5.6 biomass water productivity (WP)
         wpi = wpbio # vegetative stage
         # 5.6a. vegetative versus yield formation stage
-        if ((crop.subkind == :Tuber) | (crop.subkind == :Grain)) & (wpyield < 100) & (dayi > lflor) 
+        if ((crop.subkind == :Tuber) | (crop.subkind == :Grain)) & (wpyield < 100) & (dayi > lflor)
             # yield formation stage
             fswitch = 1
-            if (daysyieldformation > 0) & (tswitch > 0) 
+            if (daysyieldformation > 0) & (tswitch > 0)
                 fswitch = (dayi-lflor) * 1/tswitch
                 if fswitch > 1
                     fswitch = 1
-                end 
-            end 
+                end
+            end
             wpi = wpi * (1 - (1 - wpyield/100)*fswitch)
-        end 
+        end
 
         # 5.7 Biomass (B)
-        if fertilitystresson 
+        if fertilitystresson
             # 5.7a - reduction for soil fertiltiy
-            if (strresredwp > 0) & (sumkci > 0) & (sumkctopsf > eps()) 
+            if (strresredwp > 0) & (sumkci > 0) & (sumkctopsf > eps())
                 if sumkci < sumkctopsf
-                    if sumkci > 0 
+                    if sumkci > 0
                         wpi = wpi * (1 - (strresredwp/100) * exp(k*log(sumkci/sumkctopsf)))
-                    end 
+                    end
                 else
                     wpi = wpi * (1 - strresredwp/100)
-                end 
-            end 
+                end
+            end
             # 5.7b - Biomass (B)
             sumbnor = sumbnor +  wpi * (tpotforb/etostandard)
         else
             sumbnor = sumbnor +  wpi * (1 - strresredkssto/100) * (tpotforb/etostandard) # for salinity stress
-        end 
+        end
     end
 
     # 5. Export
     return sumbnor
-end 
+end
 
 """
     fweed = cc_multiplier_weed(procentweedcover, ccxcrop, fshapeweed)
@@ -1530,18 +1530,18 @@ end
 global.f90:CCmultiplierWeed:2197
 """
 function cc_multiplier_weed(procentweedcover, ccxcrop, fshapeweed)
-    if (procentweedcover > 0) & (ccxcrop < 0.9999) & (ccxcrop > 0.001) 
-        if procentweedcover == 100 
+    if (procentweedcover > 0) & (ccxcrop < 0.9999) & (ccxcrop > 0.001)
+        if procentweedcover == 100
             fweed = 1/ccxcrop
         else
             fweed = 1 - (1 - 1/ccxcrop) * (exp(fshapeweed*procentweedcover/100) - 1)/(exp(fshapeweed) - 1)
-            if fweed > (1/ccxcrop) 
+            if fweed > (1/ccxcrop)
                 fweed = 1/ccxcrop
-            end 
-        end 
+            end
+        end
     else
         fweed = 1
-    end 
+    end
 
     return fweed
 end
@@ -1556,7 +1556,7 @@ global.f90:CCiNoWaterStressSF:1409
 function cci_no_water_stress_sf(dayi, l0, l12sf, l123, l1234, gddl0,
     gddl12sf, gddl123, gddl1234, cco, ccx, cgc, gddcgc, cdc, gddcdc, sumgdd,
     ratdgdd, sfredcgc, sfredccx, sfcdecline, themodecycle, simulation)
-    
+
     # Calculate CCi
     cci = canopy_cover_no_stress_sf(dayi, l0, l123, l1234, gddl0, gddl123,
                                 gddl1234, cco, ccx, cgc, cdc, gddcgc,
@@ -1564,20 +1564,20 @@ function cci_no_water_stress_sf(dayi, l0, l12sf, l123, l1234, gddl0,
                                 sfredccx, simulation)
 
     # Consider CDecline for limited soil fertiltiy
-    if (dayi > l12sf) & (sfcdecline > ac_zero_threshold) & (l12sf < l123) 
+    if (dayi > l12sf) & (sfcdecline > ac_zero_threshold) & (l12sf < l123)
         if dayi < l123
-            if themodecycle == :CalendarDays 
+            if themodecycle == :CalendarDays
                 cci = cci - (sfcdecline/100) * exp(2*log(dayi-l12sf))/(l123-l12sf)
             else
-                if (sumgdd > gddl12sf) & (gddl123 > gddl12sf) 
+                if (sumgdd > gddl12sf) & (gddl123 > gddl12sf)
                     cci = cci - (ratdgdd*sfcdecline/100) * exp(2*log(sumgdd-gddl12sf)) / (gddl123-gddl12sf)
                 end
-            end 
-            if cci < 0 
+            end
+            if cci < 0
                 cci = 0
-            end 
+            end
         else
-            if themodecycle == :CalendarDays 
+            if themodecycle == :CalendarDays
                 cci = cc_at_time((l123-l0), cco, (cgc*(1-sfredcgc/100)), ((1-sfredccx/100)*ccx))
                 # ccibis is cc in late season when canopy decline continues
                 ccibis = cci  - (sfcdecline/100) * (exp(2*log(dayi-l12sf)) / (l123-l12sf))
@@ -1585,7 +1585,7 @@ function cci_no_water_stress_sf(dayi, l0, l12sf, l123, l1234, gddl0,
                     cci = 0
                 else
                     cci = cci  - ((sfcdecline/100) * (l123-l12sf))
-                end 
+                end
                 if cci < 0.001
                     cci = 0
                 else
@@ -1593,19 +1593,19 @@ function cci_no_water_stress_sf(dayi, l0, l12sf, l123, l1234, gddl0,
                     # decline with soil fertility stress
                     ccxadj = cci
                     cdcadj = cdc * (ccxadj + 2.29)/(ccx + 2.29)
-                    if dayi < (l123 + length_canopy_decline(ccxadj, cdcadj)) 
+                    if dayi < (l123 + length_canopy_decline(ccxadj, cdcadj))
                         cci = ccxadj * (1-0.05*(exp((dayi-l123)*3.33*cdcadj/(ccxadj+2.29))-1))
-                        if ccibis < cci 
+                        if ccibis < cci
                             cci = ccibis # accept smallest canopy cover
                         end
                     else
                         cci = 0
                     end
-                end 
+                end
             else
                 cci = cc_at_time((gddl123-gddl0), cco, (gddcgc*(1-sfredcgc/100)), ((1-sfredccx/100)*ccx))
                 # ccibis is cc in late season when canopy decline continues
-                if (sumgdd > gddl12sf) & (gddl123 > gddl12sf) 
+                if (sumgdd > gddl12sf) & (gddl123 > gddl12sf)
                     ccibis = cci  - (ratdgdd*sfcdecline/100) * (exp(2*log(sumgdd-gddl12sf))/(gddl123-gddl12sf))
                 else
                     ccibis = cci
@@ -1614,7 +1614,7 @@ function cci_no_water_stress_sf(dayi, l0, l12sf, l123, l1234, gddl0,
                     cci = 0
                 else
                     cci = cci - ((ratdgdd*sfcdecline/100) * (gddl123-gddl12sf))
-                end 
+                end
                 if cci < 0.001
                     cci = 0
                 else
@@ -1622,24 +1622,24 @@ function cci_no_water_stress_sf(dayi, l0, l12sf, l123, l1234, gddl0,
                     # decline with soil fertility stress
                     ccxadj = cci
                     gddcdcadj = gddcdc * (ccxadj + 2.29)/(ccx + 2.29)
-                    if sumgdd < (gddl123 + length_canopy_decline(ccxadj, gddcdcadj)) 
+                    if sumgdd < (gddl123 + length_canopy_decline(ccxadj, gddcdcadj))
                         cci = ccxadj * (1 - 0.05*(exp((sumgdd-gddl123)*3.33*gddcdcadj/(ccxadj+2.29))-1))
                         if ccibis < cci
                             cci = ccibis # accept smallest canopy cover
-                        end 
+                        end
                     else
                         cci = 0
-                    end 
-                end 
-            end 
+                    end
+                end
+            end
             if cci < 0
                 cci = 0
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     return cci
-end 
+end
 
 """
     cci = cc_at_time(dayi, ccoin, cgcin, ccxin)
@@ -1648,85 +1648,85 @@ global.f90:CCatTime:2388
 """
 function cc_at_time(dayi, ccoin, cgcin, ccxin)
     cci = ccoin * exp(cgcin * dayi)
-    if cci > ccxin/2 
+    if cci > ccxin/2
         cci = ccxin - 0.25 * (ccxin/ccoin) * ccxin * exp(-cgcin*dayi)
-    end 
+    end
     return cci
 end
 
 """
     weedrcdaycalc, tempweeddeltarc = get_weed_rc(theday, gddayi, fccx, tempweedrcinput, tempweedadj,
-                            tempweeddeltarc, l12sf, templ123, gddl12sf, 
+                            tempweeddeltarc, l12sf, templ123, gddl12sf,
                             tempgddl123, themodecycle)
 
 global.f90:GetWeedRC:1584
 """
 function get_weed_rc(theday, gddayi, fccx, tempweedrcinput, tempweedadj,
-                            tempweeddeltarc, l12sf, templ123, gddl12sf, 
+                            tempweeddeltarc, l12sf, templ123, gddl12sf,
                             tempgddl123, themodecycle)
 
     weedrcdaycalc = tempweedrcinput
 
-    if (tempweedrcinput > 0) & (tempweeddeltarc != 0) 
+    if (tempweedrcinput > 0) & (tempweeddeltarc != 0)
         # daily RC when increase/decline of RC in season (i.e. TempWeedDeltaRC <> 0)
         # adjust the slope of increase/decline of RC in case of self-thinning (i.e. fCCx < 1)
-        if (tempweeddeltarc != 0) & (fccx < 0.999) 
+        if (tempweeddeltarc != 0) & (fccx < 0.999)
             # only when self-thinning and there is increase/decline of RC
             if fccx < 0.005
                 tempweeddeltarc = 0
             else
                 tempweeddeltarc = round(Int, tempweeddeltarc * exp(log(fccx) * (1+tempweedadj/100)))
-            end 
-        end 
+            end
+        end
 
         # calculate WeedRCDay by considering (adjusted) decline/increase of RC
-        if themodecycle == :CalendarDays 
-            if theday > l12sf 
-                if theday >= templ123 
+        if themodecycle == :CalendarDays
+            if theday > l12sf
+                if theday >= templ123
                     weedrcdaycalc = tempweedrcinput * (1 + tempweeddeltarc/100)
                 else
                     weedrcdaycalc = tempweedrcinput * (1 + (tempweeddeltarc/100) * (theday-l12sf) / (templ123-l12sf))
-                end 
-            end 
+                end
+            end
         else
-            if gddayi > gddl12sf 
-                if gddayi > tempgddl123 
+            if gddayi > gddl12sf
+                if gddayi > tempgddl123
                     weedrcdaycalc = tempweedrcinput * (1 + tempweeddeltarc/100)
                 else
                     weedrcdaycalc = tempweedrcinput * (1 + (tempweeddeltarc/100) * (gddayi-gddl12sf) / (tempgddl123-gddl12sf))
-                end 
-            end 
-        end 
+                end
+            end
+        end
 
         # fine-tuning for over- or undershooting in case of self-thinning
-        if fccx < 0.999 
+        if fccx < 0.999
             # only for self-thinning
-            if (fccx < 1) & (fccx > 0) & (weedrcdaycalc > 98) 
+            if (fccx < 1) & (fccx > 0) & (weedrcdaycalc > 98)
                 weedrcdaycalc = 98
-            end 
-            if weedrcdaycalc < 0 
+            end
+            if weedrcdaycalc < 0
                 weedrcdaycalc = 0
-            end 
-            if fccx <= 0 
+            end
+            if fccx <= 0
                 weedrcdaycalc = 100
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     return weedrcdaycalc
 end
 
 """
-    stress_response = crop_stress_parameters_soil_salinity(ccxred, ccdistortion, 
-             cco, ccx, cgc, gddcgc, cropdeterm, l12, lflor, 
-             lengthflor, l123, gddl12, gddlflor, gddlengthflor, 
+    stress_response = crop_stress_parameters_soil_salinity(ccxred, ccdistortion,
+             cco, ccx, cgc, gddcgc, cropdeterm, l12, lflor,
+             lengthflor, l123, gddl12, gddlflor, gddlengthflor,
              gddl123, themodecycle)
 
 tempprocessing.f90:CropStressParametersSoilSalinity:1766
 """
-function crop_stress_parameters_soil_salinity(ccxred, ccdistortion, 
-             cco, ccx, cgc, gddcgc, cropdeterm, l12, lflor, 
-             lengthflor, l123, gddl12, gddlflor, gddlengthflor, 
+function crop_stress_parameters_soil_salinity(ccxred, ccdistortion,
+             cco, ccx, cgc, gddcgc, cropdeterm, l12, lflor,
+             lengthflor, l123, gddl12, gddlflor, gddlengthflor,
              gddl123, themodecycle)
     # initialize
     stress_response = RepEffectStress()
@@ -1738,98 +1738,98 @@ function crop_stress_parameters_soil_salinity(ccxred, ccdistortion,
 
     # CGC reduction
     cctoreach = 0.98 * ccx
-    if (cco > cctoreach) | (cco >= ccx) | (ccxred == 0) 
+    if (cco > cctoreach) | (cco >= ccx) | (ccxred == 0)
         stress_response.RedCGC = 0
     else
         stress_response.RedCGC = undef_int
         # reference for no salinity stress
-        if themodecycle == :CalendarDays 
+        if themodecycle == :CalendarDays
             l12double = log((0.25*ccx*ccx/cco)/(ccx-cctoreach))/cgc
-            if l12double <= eps() 
+            if l12double <= eps()
                 stress_response.RedCGC = 0
-            end 
+            end
         else
             gddl12double = log((0.25*ccx*ccx/cco)/(ccx-cctoreach))/gddcgc
-            if gddl12double <= eps() 
+            if gddl12double <= eps()
                 stress_response.RedCGC = 0
-            end 
-        end 
+            end
+        end
         # with salinity stress
         ccxadj = 0.90 * ccx * (1 - ccxred/100)
         cctoreach = 0.98 * ccxadj
-        if (stress_response.RedCGC != 0) & ((ccxadj-cctoreach) >= 0.0001) 
+        if (stress_response.RedCGC != 0) & ((ccxadj-cctoreach) >= 0.0001)
             if themodecycle == :CalendarDays
                 cgcadjmax = log((0.25*ccxadj*ccxadj/cco)/(ccxadj-cctoreach))/l12double
                 l12ssmax = l12 + (l123 - l12)/2
-                if cropdeterm & (l12ssmax > (lflor + round(Int, lengthflor/2))) 
+                if cropdeterm & (l12ssmax > (lflor + round(Int, lengthflor/2)))
                     l12ssmax = lflor + round(Int, lengthflor/2)
-                end 
-                if l12ssmax > l12double 
+                end
+                if l12ssmax > l12double
                     cgcadjmin = log((0.25*ccxadj*ccxadj/cco)/(ccxadj-cctoreach))/l12ssmax
                 else
                     cgcadjmin = cgcadjmax
-                end 
+                end
                 if ccxred < 10  # smooth start required
                     cgcadj = cgcadjmax - (cgcadjmax-cgcadjmin)*(exp(ccxred*log(1.5))/exp(10*log(1.5)))*(ccdistortion/100)
                 else
                     cgcadj = cgcadjmax - (cgcadjmax-cgcadjmin)*(ccdistortion/100)
-                end 
+                end
                 stress_response.RedCGC = round(Int, 100*(cgc-cgcadj)/cgc)
             else
                 gddcgcadjmax = log((0.25*ccxadj*ccxadj/cco)/(ccxadj-cctoreach))/gddl12double
                 gddl12ssmax = gddl12 + (gddl123 - gddl12)/2
-                if cropdeterm & (gddl12ssmax > (gddlflor + round(Int, lengthflor/2))) 
+                if cropdeterm & (gddl12ssmax > (gddlflor + round(Int, lengthflor/2)))
                     gddl12ssmax = gddlflor + round(Int, gddlengthflor/2)
-                end 
-                if gddl12ssmax > gddl12double 
+                end
+                if gddl12ssmax > gddl12double
                     gddcgcadjmin = log((0.25*ccxadj*ccxadj/cco)/(ccxadj-cctoreach))/gddl12ssmax
                 else
                     gddcgcadjmin = gddcgcadjmax
-                end 
+                end
                 if ccxred < 10  # smooth start required
                     gddcgcadj = gddcgcadjmax - (gddcgcadjmax-gddcgcadjmin)*(exp(ccxred)/exp(10))*(ccdistortion/100)
                 else
                     gddcgcadj = gddcgcadjmax - (gddcgcadjmax-gddcgcadjmin)*(ccdistortion/100)
-                end 
+                end
                 stress_response.RedCGC = round(Int, 100*(gddcgc-gddcgcadj)/gddcgc)
-           end 
+           end
         else
             stress_response.RedCGC = 0
-        end 
-    end 
+        end
+    end
 
     # Canopy decline
-    if ccxred == 0 
+    if ccxred == 0
         stress_response.CDecline = 0
     else
         ccxadj = 0.98*ccx*(1 - ccxred/100)
         l12ss = l12ssmax - (l12ssmax-l12double) * (ccdistortion/100)
-        if (l123 > l12ss) & (ccdistortion > 0) 
+        if (l123 > l12ss) & (ccdistortion > 0)
             if ccxred < 10  # smooth start required
                 ccxfinal = ccxadj - (exp(ccxred*log(1.5))/exp(10*log(1.5)))*(0.5*ccdistortion/100)*(ccxadj - cco)
             else
                 ccxfinal = ccxadj - (0.5*ccdistortion/100)*(ccxadj - cco)
-            end 
-            if ccxfinal < cco 
+            end
+            if ccxfinal < cco
                 ccxfinal = cco
-            end 
+            end
             stress_response.CDecline = 100*(ccxadj - ccxfinal)/(l123 - l12ss)
             if stress_response.CDecline > 1
                 stress_response.CDecline = 1
-            end 
-            if stress_response.CDecline <= eps() 
+            end
+            if stress_response.CDecline <= eps()
                 stress_response.CDecline = 0.001
-            end 
+            end
         else
             stress_response.CDecline = 0.001 # no shift of maturity
-        end 
-    end 
+        end
+    end
 
     # Stomata closure
     stress_response.RedKsSto = ccxred
 
     return stress_response
-end 
+end
 
 """
     fccx = multiplier_ccx_self_thinning(yeari, yearx, shapefactor)
@@ -1838,17 +1838,17 @@ global.f90:MultiplierCCxSelfThinning:1801
 """
 function multiplier_ccx_self_thinning(yeari, yearx, shapefactor)
     fccx = 1
-    if (yeari >= 2) & (yearx >= 2) & (round(Int, 100*shapefactor) != 0) 
+    if (yeari >= 2) & (yearx >= 2) & (round(Int, 100*shapefactor) != 0)
         year0 = 1 + (yearx-1) * exp(shapefactor*log(10))
         if yeari >= year0
             fccx = 0
         else
             fccx = 0.9 + 0.1 * (1 - exp((1/shapefactor)*log((yeari-1)/(yearx-1))))
-        end 
-        if fccx < 0 
+        end
+        if fccx < 0
             fccx = 0
-        end 
-    end 
+        end
+    end
     return fccx
 end
 
@@ -1860,20 +1860,20 @@ global.f90:CCmultiplierWeedAdjusted:2221
 function cc_multiplier_weed_adjusted(procentweedcover, ccxcrop, fshapeweed, fccx, yeari, mweedadj, cropsubkind)
     fweedi = 1
     rcadj = procentweedcover
-    if procentweedcover > 0 
+    if procentweedcover > 0
         fweedi = cc_multiplier_weed(procentweedcover, ccxcrop, fshapeweed)
         # FOR perennials when self-thinning
-        if (cropsubkind == :Forage) & (yeari > 1) & (fccx < 0.995) 
+        if (cropsubkind == :Forage) & (yeari > 1) & (fccx < 0.995)
             # need for adjustment
             # step 1 - adjusment of shape factor to degree of crop replacement by weeds
             fshapeminimum = 10 - 20*( (exp(fccx*3)-1)/(exp(3)-1) + sqrt(mweedadj/100))
-            if round(Int, fshapeminimum*10) == 0 
+            if round(Int, fshapeminimum*10) == 0
                 fshapeminimum = 0.1
-            end 
+            end
             fshapeweed = fshapeweed;
-            if fshapeweed < fshapeminimum 
+            if fshapeweed < fshapeminimum
                 fshapeweed = fshapeminimum
-            end 
+            end
 
             # step 2 - Estimate of CCxTot
             # A. Total CC (crop and weeds) when self-thinning and 100% weed take over
@@ -1884,19 +1884,19 @@ function cc_multiplier_weed_adjusted(procentweedcover, ccxcrop, fshapeweed, fccx
                 fweedi = cc_multiplier_weed(round(Int, fccx*procentweedcover), (fccx*ccxcrop), fshapeweed)
             else
                 fweedi = 1
-            end 
+            end
             ccxtot0 = fweedi * (fccx*ccxcrop)
             # C. total CC (crop and weeds) with specified weed take over (MWeedAdj)
             ccxtotm = ccxtot0 + (ccxtot100 - ccxtot0)* mweedadj/100
-            if ccxtotm < (fccx*ccxcrop*(1-procentweedcover/100)) 
+            if ccxtotm < (fccx*ccxcrop*(1-procentweedcover/100))
                 ccxtotm = fccx*ccxcrop*(1-procentweedcover/100)
-            end 
-            if fccx > 0.005 
+            end
+            if fccx > 0.005
                 fweedi = ccxtotm/(fccx*ccxcrop)
                 fweedmax = 1/(fccx*ccxcrop)
-                if round(Int, fweedi*1000) > round(Int, fweedmax*1000) 
+                if round(Int, fweedi*1000) > round(Int, fweedmax*1000)
                     fweedi = fweedmax
-                end 
+                end
             end
 
             # step 3 - Estimate of adjusted weed cover
@@ -1904,20 +1904,20 @@ function cc_multiplier_weed_adjusted(procentweedcover, ccxcrop, fshapeweed, fccx
             if fccx > 0.005
                 if rcadjd < (100*(ccxtotm - fccx*ccxcrop)/ccxtotm)
                     rcadjd = 100*(ccxtotm - fccx*ccxcrop)/ccxtotm
-                end 
-                if rcadjd > (100 * (1- (fccx*ccxcrop*(1-procentweedcover/100)/ccxtotm))) 
+                end
+                if rcadjd > (100 * (1- (fccx*ccxcrop*(1-procentweedcover/100)/ccxtotm)))
                     rcadjd = 100*(1- fccx*ccxcrop*(1-procentweedcover/100)/ccxtotm)
-                end 
-            end 
+                end
+            end
             rcadj = round(Int, rcadjd)
             if rcadj > 100
                 rcadj = 100
             end
-        end 
-    end 
+        end
+    end
 
     return fweedi, rcadj
-end 
+end
 
 """
     fcco = multiplier_cco_self_thinning(yeari, yearx, shapefactor)
@@ -1926,17 +1926,17 @@ global.f90:MultiplierCCoSelfThinning:2605
 """
 function multiplier_cco_self_thinning(yeari, yearx, shapefactor)
     fcco = 1
-    if (yeari >= 1) & (yearx >= 2) & (round(Int, 100*shapefactor) != 0) 
+    if (yeari >= 1) & (yearx >= 2) & (round(Int, 100*shapefactor) != 0)
         year0 = 1 + (yearx-1) * exp(shapefactor*log(10))
         if (yeari >= year0) | (year0 <= 1)
             fcco = 0
         else
             fcco = 1 - (yeari-1)/(year0-1)
-        end 
+        end
         if fcco < 0
             fcco = 0
-        end 
-    end 
+        end
+    end
     return fcco
 end
 
@@ -1950,13 +1950,13 @@ function reference_stress_biomass_relationship!(outputs, gvars; kwargs...)
 
     # save values
     l0_loc = gvars[:crop].DaysToGermination
-    l12_loc = gvars[:crop].DaysToFullCanopy 
+    l12_loc = gvars[:crop].DaysToFullCanopy
     lflor_loc = gvars[:crop].DaysToFlowering
-    lengthflor_loc = gvars[:crop].LengthFlowering 
-    l123_loc = gvars[:crop].DaysToSenescence 
+    lengthflor_loc = gvars[:crop].LengthFlowering
+    l123_loc = gvars[:crop].DaysToSenescence
     l1234_loc = gvars[:crop].DaysToHarvest
     lhimax_loc = gvars[:crop].DaysToHIo
-    cgc_loc = gvars[:crop].CGC 
+    cgc_loc = gvars[:crop].CGC
     cdc_loc =   gvars[:crop].CDC
     ratedhidt_loc = gvars[:crop].dHIdt
 
@@ -1965,14 +1965,14 @@ function reference_stress_biomass_relationship!(outputs, gvars; kwargs...)
     refcropday1 = determine_day_nr(dayi, monthi, 1901)  # not linked to a specific year
 
     # 2. Create TCropReference.SIM (i.e. daily mean Tnx for 365 days from Onset onwards)
-    if length(outputs[:tnxreference365days][:tlow]) > 0 
+    if length(outputs[:tnxreference365days][:tlow]) > 0
         daily_tnxreferencefile_covering_cropperiod!(outputs, refcropday1)
-    end 
+    end
 
     # 3. Determine coresponding calendar days if crop cycle is defined in GDDays
     if gvars[:crop].ModeCycle == :GDDays
         adjust_calendardays_referencetnx!(refcropday1, outputs, gvars)
-    end 
+    end
 
     # 4. CO2 concentration for TnxReferenceYear
     if gvars[:integer_parameters][:tnxreferenceyear] == 2000
@@ -1981,11 +1981,11 @@ function reference_stress_biomass_relationship!(outputs, gvars; kwargs...)
         tnxreferenceyear = gvars[:integer_parameters][:tnxreferenceyear]
         co2_file = gvars[:string_parameters][:CO2_file]
         co2tnxreferenceyear = co2_for_tnxreferenceyear(tnxreferenceyear, co2_file; kwargs...)
-    end 
+    end
 
     # 5. Stress Biomass relationship
     stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refcropday1, outputs, gvars)
-    
+
     # restore values
     gvars[:crop].DaysToGermination = l0_loc
     gvars[:crop].DaysToFullCanopy = l12_loc
@@ -1999,7 +1999,7 @@ function reference_stress_biomass_relationship!(outputs, gvars; kwargs...)
     gvars[:crop].dHIdt = ratedhidt_loc
 
     return nothing
-end 
+end
 
 """
     daily_tnxreferencefile_covering_cropperiod!(outputs, cropfirstday)
@@ -2010,26 +2010,26 @@ function daily_tnxreferencefile_covering_cropperiod!(outputs, cropfirstday)
     # CropFirstDay = DayNr1 in undefined year
     dayi, monthi, yeari = determine_date(cropfirstday)
     daynr = determine_day_nr(dayi, monthi, 1901)
-    
+
     for dayi in daynr:365
         tlow, thigh = read_output_from_tnxreference365days(outputs, dayi)
         add_output_in_tcropreferencesim!(outputs, tlow, thigh)
-    end 
+    end
     for dayi in 1:(daynr-1)
         tlow, thigh = read_output_from_tnxreference365days(outputs, dayi)
         add_output_in_tcropreferencesim!(outputs, tlow, thigh)
-    end 
-     
+    end
+
     # after this we do not use tnxreference365months so we flush it
     flush_output_tnxreference365days!(outputs)
     return nothing
-end 
+end
 
 """
     adjust_calendardays_referencetnx!(plantdaynr, outputs, gvars)
 
 preparefertilitysalinity.f90:AdjustCalendarDaysReferenceTnx:156
-save and restore the final values 
+save and restore the final values
 """
 function adjust_calendardays_referencetnx!(plantdaynr, outputs, gvars)
     crop = gvars[:crop]
@@ -2063,66 +2063,66 @@ function adjust_calendardays_referencetnx!(plantdaynr, outputs, gvars)
     cdc = crop.CDC
     ratedhidt = crop.dHIdt
 
-    if thedaystoccini==0 
+    if thedaystoccini==0
         # planting/sowing
-        l0 = sum_calendar_days_referencetnx(gddl0, plantdaynr, plantdaynr, tbase, tupper, 
+        l0 = sum_calendar_days_referencetnx(gddl0, plantdaynr, plantdaynr, tbase, tupper,
                                             tdaymin, tdaymax, outputs, gvars)
-        l12 = sum_calendar_days_referencetnx(gddl12, plantdaynr, plantdaynr, tbase, tupper, 
+        l12 = sum_calendar_days_referencetnx(gddl12, plantdaynr, plantdaynr, tbase, tupper,
                                             tdaymin, tdaymax, outputs, gvars)
     else
         # regrowth
-        if thedaystoccini>0 
+        if thedaystoccini>0
            # ccini < ccx
            extragddays = gddl12 - gddl0 - thegddaystoccini
            extradays = sum_calendar_days_referencetnx(extragddays, plantdaynr, plantdaynr,
                                                       tbase, tupper, tdaymin, tdaymax, outputs, gvars)
            l12 = l0 + thedaystoccini + extradays
-        end 
-    end 
-    if thecroptype != :Forage 
+        end
+    end
+    if thecroptype != :Forage
         l123 = sum_calendar_days_referencetnx(gddl123, plantdaynr, plantdaynr, tbase, tupper,
                                                 tdaymin, tdaymax, outputs, gvars)
         l1234 = sum_calendar_days_referencetnx(gddl1234, plantdaynr, plantdaynr, tbase, tupper,
                                                 tdaymin, tdaymax, outputs, gvars)
-    end 
+    end
 
     if (thecroptype==:Grain) | (thecroptype==:Tuber)
-        lflor = sum_calendar_days_referencetnx(gddflor, plantdaynr, plantdaynr, tbase, tupper, 
+        lflor = sum_calendar_days_referencetnx(gddflor, plantdaynr, plantdaynr, tbase, tupper,
                                                 tdaymin, tdaymax, outputs, gvars)
-        if thecroptype==:Grain 
-            lengthflor = sum_calendar_days_referencetnx(gddlengthflor, plantdaynr, 
+        if thecroptype==:Grain
+            lengthflor = sum_calendar_days_referencetnx(gddlengthflor, plantdaynr,
                             (plantdaynr+lflor), tbase, tupper, tdaymin, tdaymax, outputs, gvars)
         else
             lengthflor = 0
-        end 
+        end
         lhimax = sum_calendar_days_referencetnx(gddhimax, plantdaynr, (plantdaynr+lflor),
                                                 tbase, tupper, tdaymin, tdaymax, outputs, gvars)
     elseif (thecroptype==:Vegetative) | (thecroptype==:Forage)
         lhimax = sum_calendar_days_referencetnx(gddhimax, plantdaynr, plantdaynr, tbase, tupper,
                                                 tdaymin, tdaymax, outputs, gvars)
-    end 
+    end
 
     cgc = gddl12/l12 * gddcgc
     cdc = gddcdc_to_cdc(plantdaynr, l123, gddl123, gddl1234, ccx, gddcdc, tbase, tupper, tdaymin, tdaymax, gvars)
-    if (thecroptype==:Grain) | (thecroptype==:Tuber) 
+    if (thecroptype==:Grain) | (thecroptype==:Tuber)
         ratedhidt = refhi/lhimax
-    end 
-    if (thecroptype==:Vegetative) | (thecroptype==:Forage) 
-        if lhimax > 0 
-            if lhimax > l1234 
+    end
+    if (thecroptype==:Vegetative) | (thecroptype==:Forage)
+        if lhimax > 0
+            if lhimax > l1234
                 ratedhidt = refhi/l1234
             else
                 ratedhidt = refhi/lhimax
-            end 
+            end
             if ratedhidt > 100
                 ratedhidt = 100 # 100 is maximum tempdhidt (see setdhidt)
                 lhimax = 0
-            end 
+            end
         else
             ratedhidt = 100 # 100 is maximum tempdhidt (see setdhidt)
             lhimax = 0
-        end 
-    end 
+        end
+    end
 
     gvars[:crop].DaysToGermination = l0
     gvars[:crop].DaysToFullCanopy = l12
@@ -2136,7 +2136,7 @@ function adjust_calendardays_referencetnx!(plantdaynr, outputs, gvars)
     gvars[:crop].dHIdt = ratedhidt
 
     return nothing
-end 
+end
 
 """
     nrcdays = sum_calendar_days_referencetnx(valgddays, refcropday1, startdaynr, tbase, tupper, tdaymin, tdaymax, outputs, gvars)
@@ -2151,14 +2151,14 @@ function sum_calendar_days_referencetnx(valgddays, refcropday1, startdaynr, tbas
 
     nrcdays = 0
     if valgddays > 0
-        if length(outputs[:tcropreferencesim][:tlow]) == 0 
+        if length(outputs[:tcropreferencesim][:tlow]) == 0
             # given average Tmin and Tmax
             daygdd = degrees_day(tbase, tupper, tdaymin_loc, tdaymax_loc, simulparam.GDDMethod)
             if abs(daygdd) < eps()
-                nrcdays = 0 
+                nrcdays = 0
             else
                 nrcdays = round(Int, valgddays/daygdd)
-            end 
+            end
         else
             # Get TCropReference: mean daily Tnx (365 days) from RefCropDay1 onwards
             # determine corresponding calendar days
@@ -2169,22 +2169,22 @@ function sum_calendar_days_referencetnx(valgddays, refcropday1, startdaynr, tbas
 
             while remaininggddays > 0.1
                 i = i + 1
-                if i == length(outputs[:tcropreferencesim][:tlow])  # OJO maybe i>length 
+                if i == length(outputs[:tcropreferencesim][:tlow])  # OJO maybe i>length
                     i = 1
-                end 
+                end
                 tdaymin_loc, tdaymax_loc = read_output_from_tcropreferencesim(outputs, i)
                 daygdd = degrees_day(tbase, tupper, tdaymin_loc, tdaymax_loc, simulparam.GDDMethod)
                 if daygdd > remaininggddays
                     if round(Int, (daygdd-remaininggddays)/remaininggddays) >= 1
                         nrcdays = nrcdays + 1
-                    end 
+                    end
                 else
                     nrcdays = nrcdays + 1
-                end 
+                end
                 remaininggddays = remaininggddays - daygdd
-            end 
-        end 
-    end 
+            end
+        end
+    end
     return nrcdays
 end
 
@@ -2222,14 +2222,14 @@ function co2_for_tnxreferenceyear(tnxreferenceyear, co2_file; kwargs...)
                     if (round(Int, yearb) >= tnxreferenceyear) | eof(file)
                         loop_1 = false
                     end
-                end 
-                if tnxreferenceyear > round(Int, yearb) 
+                end
+                if tnxreferenceyear > round(Int, yearb)
                     theco2 = co2b
                 else
                     theco2 = co2a + (co2b-co2a)*(tnxreferenceyear-round(Int, yeara))/(round(Int, yearb)-round(Int, yeara))
-                end 
+                end
             end
-        end 
+        end
     else
         # OJO we need a method when  NoFileRun
         if haskey(kwargs, :co2i)
@@ -2290,7 +2290,7 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
     stress_matrix = StressIndexesBio[StressIndexesBio() for _ in 1:8]
 
     # 1. initialize
-    bnor100 = undef_double 
+    bnor100 = undef_double
     # to calculate SumKcTop (no stress)
     l12sf = l12
     # to calculate SumKcTop (no stress)
@@ -2300,24 +2300,24 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
     sumkctop = seasonal_sum_of_kcpot(outputs, thedaystoccini, thegddaystoccini,
         l0, l12, l123, l1234, gddl0, gddl12, gddl123, gddl1234,
         cco, ccx, cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing,
-        cceffectprocent, tbase, tupper, tdaymin, tdaymax, 
+        cceffectprocent, tbase, tupper, tdaymin, tdaymax,
         gdtransplow, co2tnxreferenceyear, themodecycle, simulation, simulparam, true)
 
     # Get PercentLagPhase (for estimate WPi during yield formation)
-    if (thecroptype == :Tuber) | (thecroptype == :Grain) 
+    if (thecroptype == :Tuber) | (thecroptype == :Grain)
         # DaysToFlowering corresponds with Tuberformation
         daysyieldformation = round(Int, refhi/ratedhidt)
-        if cropdeterm 
+        if cropdeterm
             higc = harvest_index_growth_coefficient(refhi, ratedhidt)
             tswitch, higclinear = get_day_switch_to_linear(refhi, ratedhidt, higc)
         else
             tswitch = round(Int, daysyieldformation/3)
-        end 
+        end
     else
-        # assign default values 
+        # assign default values
         daysyieldformation = undef_int
         tswitch = undef_int
-    end 
+    end
 
     # 2. Biomass production for various stress levels
     for si in 1:8
@@ -2337,18 +2337,18 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
                                     lengthflor, cropdeterm,
                                     l12sf, stress_response.RedCGC,
                                     stress_response.RedCCX, sipr)
-            if themodecycle == :GDDays 
+            if themodecycle == :GDDays
                 gddl12sf = sum_calendar_days_referencetnx(l12sf, refcropday1, refcropday1, tbase, tupper, tdaymin, tdaymax, outputs, gvars)
-            end 
-            if (themodecycle == :GDDays) & (gddl12sf < gddl123) 
+            end
+            if (themodecycle == :GDDays) & (gddl12sf < gddl123)
                 ratdgdd = (l123-l12sf)*1/(gddl123-gddl12sf)
-            end 
-        end 
+            end
+        end
         # biomass production
         simulation.DelayedDays = 0 #note that we must do this before calling bnormalized
         bnor = bnormalized(outputs, thedaystoccini, thegddaystoccini,
                 l0, l12, l12sf, l123, l1234, lflor,
-                gddl0, gddl12, gddl12sf, gddl123, gddl1234, wpyield, 
+                gddl0, gddl12, gddl12sf, gddl123, gddl1234, wpyield,
                 daysyieldformation, tswitch, cco, ccx, cgc, gddcgc, cdc,
                 gddcdc, kctop, kcdeclageing, cceffectprocent, wpveg, co2tnxreferenceyear,
                 tbase, tupper, tdaymin, tdaymax, gdtransplow, ratdgdd,
@@ -2356,19 +2356,19 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
                 stress_response.RedWP, stress_response.RedKsSto, 0, 0,
                 stress_response.CDecline, -0.01, themodecycle, true,
                 simulation, simulparam, management, crop, true)
-        if si == 1 
+        if si == 1
             bnor100 = bnor
             stress_matrix[1].BioMProc = 100
         else
-            if bnor100 > 0.00001 
+            if bnor100 > 0.00001
                 stress_matrix[si].BioMProc = 100 * bnor/bnor100
             else
                 stress_matrix[si].BioMProc = 100
-            end 
-        end 
+            end
+        end
         stress_matrix[si].BioMSquare = stress_matrix[si].BioMProc^2
         # end stress level
-    end 
+    end
 
     # 5. Stress - Biomass relationship
     yavg = 0
@@ -2379,7 +2379,7 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
         yavg += stress_matrix[si].StressProc
         x1avg += stress_matrix[si].BioMProc
         x2avg += stress_matrix[si].BioMSquare
-    end 
+    end
     yavg  = yavg/8
     x1avg = x1avg/8
     x2avg = x2avg/8
@@ -2403,9 +2403,9 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
         sumx1sq = sumx1sq + x1sq
         sumx2sq = sumx2sq + x2sq
         sumx1x2 = sumx1x2 + x1x2
-    end 
+    end
 
-    if abs(round(Int, sumx1x2*1000)) != 0 
+    if abs(round(Int, sumx1x2*1000)) != 0
         b2 = (sumx1y - (sumx2y * sumx1sq)/sumx1x2)/
              (sumx1x2 - (sumx1sq * sumx2sq)/sumx1x2)
         b1 = (sumx1y - b2 * sumx1x2)/sumx1sq
@@ -2422,8 +2422,8 @@ function stress_biomass_relationship_for_tnxreference!(co2tnxreferenceyear, refc
         b2 = undef_double #real(undef_int, kind=dp)
         b1 = undef_double #real(undef_int, kind=dp)
         b0 = undef_double #real(undef_int, kind=dp)
-    end 
-    
+    end
+
     setparameter!(gvars[:float_parameters], :coeffb0, b0)
     setparameter!(gvars[:float_parameters], :coeffb1, b1)
     setparameter!(gvars[:float_parameters], :coeffb2, b2)
@@ -2442,13 +2442,13 @@ function reference_ccx_salt_stress_relationship!(outputs, gvars; kwargs...)
 
     # save values
     l0_loc = gvars[:crop].DaysToGermination
-    l12_loc = gvars[:crop].DaysToFullCanopy 
+    l12_loc = gvars[:crop].DaysToFullCanopy
     lflor_loc = gvars[:crop].DaysToFlowering
-    lengthflor_loc = gvars[:crop].LengthFlowering 
-    l123_loc = gvars[:crop].DaysToSenescence 
+    lengthflor_loc = gvars[:crop].LengthFlowering
+    l123_loc = gvars[:crop].DaysToSenescence
     l1234_loc = gvars[:crop].DaysToHarvest
     lhimax_loc = gvars[:crop].DaysToHIo
-    cgc_loc = gvars[:crop].CGC 
+    cgc_loc = gvars[:crop].CGC
     cdc_loc =   gvars[:crop].CDC
     ratedhidt_loc = gvars[:crop].dHIdt
 
@@ -2457,14 +2457,14 @@ function reference_ccx_salt_stress_relationship!(outputs, gvars; kwargs...)
     refcropday1 = determine_day_nr(dayi, monthi, 1901)  # not linked to a specific year
 
     # 2. Create TCropReference.SIM (i.e. daily mean Tnx for 365 days from Onset onwards)
-    if length(outputs[:tnxreference365days][:tlow]) > 0 
+    if length(outputs[:tnxreference365days][:tlow]) > 0
         daily_tnxreferencefile_covering_cropperiod!(outputs, refcropday1)
-    end 
+    end
 
     # 3. Determine coresponding calendar days if crop cycle is defined in GDDays
     if gvars[:crop].ModeCycle == :GDDays
         adjust_calendardays_referencetnx!(refcropday1, outputs, gvars)
-    end 
+    end
 
     # 4. CO2 concentration for TnxReferenceYear
     if gvars[:integer_parameters][:tnxreferenceyear] == 2000
@@ -2473,11 +2473,11 @@ function reference_ccx_salt_stress_relationship!(outputs, gvars; kwargs...)
         tnxreferenceyear = gvars[:integer_parameters][:tnxreferenceyear]
         co2_file = gvars[:string_parameters][:CO2_file]
         co2tnxreferenceyear = co2_for_tnxreferenceyear(tnxreferenceyear, co2_file; kwargs...)
-    end 
+    end
 
     # 5. Stress Biomass relationship for salinity
     ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, refcropday1, outputs, gvars)
-    
+
     # restore values
     gvars[:crop].DaysToGermination = l0_loc
     gvars[:crop].DaysToFullCanopy = l12_loc
@@ -2491,7 +2491,7 @@ function reference_ccx_salt_stress_relationship!(outputs, gvars; kwargs...)
     gvars[:crop].dHIdt = ratedhidt_loc
 
     return nothing
-end 
+end
 
 """
     ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, refcropday1, outputs, gvars)
@@ -2546,16 +2546,16 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
 
     # 1. initialize
     gddl12ss = gddl12 # to calculate sumkctop (no stress)
-    bnor100 = undef_double 
+    bnor100 = undef_double
     # Maximum sum Kc (no stress)
     simulation.DelayedDays = 0 #note that we need to do this before calling seasonal_sum_of_kcpot
     sumkctop = seasonal_sum_of_kcpot(outputs, thedaystoccini, thegddaystoccini,
                     l0, l12, l123, l1234, gddl0, gddl12, gddl123, gddl1234,
-                    cco, ccx, cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing, 
-                    cceffectprocent,tbase, tupper, tdaymin, tdaymax, gdbiolow, 
+                    cco, ccx, cgc, gddcgc, cdc, gddcdc, kctop, kcdeclageing,
+                    cceffectprocent,tbase, tupper, tdaymin, tdaymax, gdbiolow,
                     co2tnxreferenceyear, themodecycle, simulation, simulparam, true)
     # Get PercentLagPhase (for estimate WPi during yield formation)
-    if (thecroptype == :Tuber) | (thecroptype == :Grain) 
+    if (thecroptype == :Tuber) | (thecroptype == :Grain)
         # DaysToFlowering corresponds with Tuberformation
         daysyieldformation = round(Int, refhi/ratedhidt)
         if cropdeterm
@@ -2563,12 +2563,12 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
             tswitch, higclinear = get_day_switch_to_linear(refhi, ratedhidt, higc)
         else
             tswitch = round(Int, daysyieldformation/3)
-        end 
+        end
     else
-        # assign default values 
+        # assign default values
         daysyieldformation = undef_int
         tswitch = undef_int
-    end 
+    end
 
     # 2. Biomass production (or Salt stress) for various CCx reductions
     for si in 1:10
@@ -2577,29 +2577,29 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
         sipr = 10*(si-1)
         stress_matrix[si].CCxReduction = sipr
         # adjustment CC
-        stress_response = crop_stress_parameters_soil_salinity(sipr, theccsaltdistortion, 
+        stress_response = crop_stress_parameters_soil_salinity(sipr, theccsaltdistortion,
             cco, ccx, cgc, gddcgc, cropdeterm, l12, lflor, lengthflor, l123,
             gddl12, gddflor, gddlengthflor, gddl123, themodecycle)
         # adjusted length of Max canopy cover
         ratdgdd = 1
-        if (stress_response.RedCCX == 0) & (stress_response.RedCGC == 0) 
+        if (stress_response.RedCCX == 0) & (stress_response.RedCGC == 0)
             l12ss = l12
             gddl12ss = gddl12
         else
             cctoreach = 0.98*(1-stress_response.RedCCX/100)*ccx
-            l12ss = days_to_reach_cc_with_given_cgc(cctoreach, cco, 
+            l12ss = days_to_reach_cc_with_given_cgc(cctoreach, cco,
                  (1-stress_response.RedCCX/100)*ccx,
                  cgc*(1-stress_response.RedCGC/100), l0)
             if themodecycle == :GDDays
                 tdaymax_temp = tdaymax
                 tdaymin_temp = tdaymin
-                gddl12ss = growing_degree_days(l12ss, cropdnr1, tbase, 
+                gddl12ss = growing_degree_days(l12ss, cropdnr1, tbase,
                            tupper, gvars, tdaymin_temp, tdaymax_temp)
-            end 
-            if (themodecycle == :GDDays) & (gddl12ss < gddl123) 
+            end
+            if (themodecycle == :GDDays) & (gddl12ss < gddl123)
                 ratdgdd = (l123-l12ss)*1/(gddl123-gddl12ss)
-            end 
-        end 
+            end
+        end
 
         # biomass production
         simulation.DelayedDays = 0 #note that we must do this before calling bnormalized
@@ -2611,25 +2611,25 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
                 kctop, kcdeclageing, cceffectprocent, wpveg, co2tnxreferenceyear,
                 tbase, tupper, tdaymin, tdaymax, gdbiolow, ratdgdd, sumkctop,
                 sipr, stress_response.RedCGC, stress_response.RedCCX,
-                stress_response.RedWP, stress_response.RedKsSto, 
+                stress_response.RedWP, stress_response.RedKsSto,
                 0, 0, stress_response.CDecline, -0.01,
-                themodecycle, false, 
+                themodecycle, false,
                 simulation, simulparam, management, crop, true)
-        if si == 1 
+        if si == 1
             bnor100 = bnor
             biomproc = 100
             stress_matrix[1].SaltProc = 0
         else
-            if bnor100 > 0.00001 
+            if bnor100 > 0.00001
                 biomproc = 100 * bnor/bnor100
                 stress_matrix[si].SaltProc = 100 - biomproc
             else
                 stress_matrix[si].SaltProc = 0
-            end 
-        end 
+            end
+        end
         stress_matrix[si].SaltSquare = stress_matrix[si].SaltProc^2
         # end stress level
-    end 
+    end
 
     # 3. CCx - Salt stress relationship
     yavg = 0
@@ -2640,7 +2640,7 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
         yavg += stress_matrix[si].CCxReduction
         x1avg += stress_matrix[si].SaltProc
         x2avg += stress_matrix[si].SaltSquare
-    end 
+    end
     yavg  = yavg/10
     x1avg = x1avg/10
     x2avg = x2avg/10
@@ -2664,9 +2664,9 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
         sumx1sq = sumx1sq + x1sq
         sumx2sq = sumx2sq + x2sq
         sumx1x2 = sumx1x2 + x1x2
-    end 
+    end
 
-    if abs(round(Int, sumx1x2*1000)) != 0 
+    if abs(round(Int, sumx1x2*1000)) != 0
         coeffb2salt = (sumx1y - (sumx2y * sumx1sq)/sumx1x2)/(sumx1x2 - (sumx1sq * sumx2sq)/sumx1x2)
         coeffb1salt = (sumx1y - coeffb2salt * sumx1x2)/sumx1sq
         coeffb0salt = yavg - coeffb1salt*x1avg - coeffb2salt*x2avg
@@ -2684,10 +2684,10 @@ function ccx_salt_stress_relationship_for_tnxreference!(co2tnxreferenceyear, ref
         coeffb2salt = undef_double #real(undef_int, kind=dp)
         coeffb1salt = undef_double #real(undef_int, kind=dp)
         coeffb0salt = undef_double #real(undef_int, kind=dp)
-    end 
+    end
     setparameter!(gvars[:float_parameters], :coeffb0salt, coeffb0salt)
     setparameter!(gvars[:float_parameters], :coeffb1salt, coeffb1salt)
     setparameter!(gvars[:float_parameters], :coeffb2salt, coeffb2salt)
 
     return nothing
-end 
+end

--- a/src/initialize_runpart2.jl
+++ b/src/initialize_runpart2.jl
@@ -183,30 +183,30 @@ function create_daily_climfiles!(outputs, gvars; kwargs...)
 
         elseif temperature_record.Datatype == :Decadely
             get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, fromsimday,
-                                            (Tmin, Tmax), 
+                                            (Tmin, Tmax),
                                             temperature_record)
             i = 1
             while tmin_dataset[i].DayNr != fromsimday
                 i = i+1
             end
-            tlow = tmin_dataset[i].Param 
-            thigh = tmax_dataset[i].Param 
+            tlow = tmin_dataset[i].Param
+            thigh = tmax_dataset[i].Param
             # setparameter!(gvars[:float_parameters], :tmin, tlow)
             # setparameter!(gvars[:float_parameters], :tmax, thigh)
 
         elseif temperature_record.Datatype == :Monthly
             get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, fromsimday,
-                                            (Tmin, Tmax), 
+                                            (Tmin, Tmax),
                                             temperature_record)
             i = 1
-            while tmin_dataset[1].DayNr != fromsimday 
+            while tmin_dataset[1].DayNr != fromsimday
                 i += 1
             end
-            tlow = tmin_dataset[i].Param 
-            thigh = tmax_dataset[i].Param 
+            tlow = tmin_dataset[i].Param
+            thigh = tmax_dataset[i].Param
             # setparameter!(gvars[:float_parameters], :tmin, tlow)
             # setparameter!(gvars[:float_parameters], :tmax, thigh)
-        end 
+        end
 
         # we do no create TempData.SIM but we use outputs variable
         add_output_in_tempdatasim!(outputs, tlow, thigh)
@@ -224,32 +224,32 @@ function create_daily_climfiles!(outputs, gvars; kwargs...)
             elseif temperature_record.Datatype == :Decadely
                 if runningday>tmin_dataset[31].DayNr
                     get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, runningday,
-                                                    (Tmin, Tmax), 
+                                                    (Tmin, Tmax),
                                                     temperature_record)
                 end
                 i = 1
                 while tmin_dataset[1].DayNr != runningday
                     i += 1
-                end 
-                tlow = tmin_dataset[i].Param 
-                thigh = tmax_dataset[i].Param 
+                end
+                tlow = tmin_dataset[i].Param
+                thigh = tmax_dataset[i].Param
 
             elseif temperature_record.Datatype == :Monthly
                 if runningday>tmin_dataset[31].DayNr
                     get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, runningday,
-                                                     (Tmin, Tmax), 
+                                                     (Tmin, Tmax),
                                                      temperature_record)
-                end 
-                i = 1 
+                end
+                i = 1
                 while tmin_dataset[1].DayNr != runningday
                     i += 1
                 end
-                tlow = tmin_dataset[i].Param 
-                thigh = tmax_dataset[i].Param 
+                tlow = tmin_dataset[i].Param
+                thigh = tmax_dataset[i].Param
             end
             add_output_in_tempdatasim!(outputs, tlow, thigh)
         end
-    end 
+    end
 
     return nothing
 end
@@ -911,12 +911,12 @@ function open_climfiles_and_get_data_firstday!(outputs, gvars; kwargs...)
     if gvars[:bool_parameters][:temperature_file_exists]
         if firstdaynr == simulation.FromDayNr
             i = 1
-            tlow, thigh = read_output_from_tempdatasim(outputs, i) 
+            tlow, thigh = read_output_from_tempdatasim(outputs, i)
             setparameter!(gvars[:float_parameters], :tmin, tlow)
             setparameter!(gvars[:float_parameters], :tmax, thigh)
         else
             i = firstdaynr - simulation.FromDayNr + 1
-            tlow, thigh = read_output_from_tempdatasim(outputs, i) 
+            tlow, thigh = read_output_from_tempdatasim(outputs, i)
             setparameter!(gvars[:float_parameters], :tmin, tlow)
             setparameter!(gvars[:float_parameters], :tmax, thigh)
         end
@@ -941,12 +941,12 @@ function initialize_run_part2!(outputs, gvars, nrrun; kwargs...)
 
     if gvars[:bool_parameters][:part1Mult]
         write_title_part1_mult_results!(outputs, gvars, nrrun)
-    end 
+    end
 
 
     if gvars[:bool_parameters][:part2Eval] & (gvars[:string_parameters][:observations_file] != "(None)")
         create_eval_data!(gvars)
-    end 
+    end
 
     return nothing
 end
@@ -1231,7 +1231,7 @@ function initialize_simulation_run_part2!(outputs, gvars, projectinput::ProjectI
         if gvars[:integer_parameters][:daynri] > gvars[:crop].DayN
             setparameter!(gvars[:float_parameters], :ziprev, undef_double)
         else
-            #must set simulation.SCor = 1  before calling this function 
+            #must set simulation.SCor = 1  before calling this function
             gvars[:simulation].SCor = 1
             ziprev = actual_rooting_depth(
                 gvars[:integer_parameters][:daynri] - gvars[:crop].Day1,
@@ -1523,7 +1523,7 @@ function get_sumgdd_before_simulation!(gvars)
         dgrd = degrees_day(gvars[:crop].Tbase, gvars[:crop].Tupper,
             tmin, tmax,
             gvars[:simulparam].GDDMethod)
-        sumgddfromday1 = sumgdd - dgrd 
+        sumgddfromday1 = sumgdd - dgrd
         gvars[:simulation].SumGDDfromDay1 = sumgddfromday1
         setparameter!(gvars[:float_parameters], :tmin, tmin)
         setparameter!(gvars[:float_parameters], :tmax, tmax)
@@ -1606,11 +1606,11 @@ end
 
 
 """
-    zr = actual_rooting_depth(dap, l0, lzmax, l1234, gddl0, gddlzmax, 
+    zr = actual_rooting_depth(dap, l0, lzmax, l1234, gddl0, gddlzmax,
                               sumgdd, zmin, zmax, shapefactor, typedays, gvars)
 
 global.f90:ActualRootingDepth:7299
-must set simulation.SCor = 1  before calling this function 
+must set simulation.SCor = 1  before calling this function
 """
 function actual_rooting_depth(dap, l0, lzmax, l1234, gddl0, gddlzmax,
     sumgdd, zmin, zmax, shapefactor, typedays, gvars)
@@ -1736,11 +1736,11 @@ run.f90:OpenHarvestInfo:5908
 """
 function open_harvest_info!(gvars, path; kwargs...)
     if gvars[:string_parameters][:man_file] != "(None)"
-        if typeof(kwargs[:runtype]) == NormalFileRun 
+        if typeof(kwargs[:runtype]) == NormalFileRun
             man_file = gvars[:string_parameters][:man_file]
-        elseif typeof(kwargs[:runtype]) == TomlFileRun 
+        elseif typeof(kwargs[:runtype]) == TomlFileRun
             man_file = gvars[:string_parameters][:man_file][1:end-5] * ".csv"
-        elseif typeof(kwargs[:runtype]) == NoFileRun 
+        elseif typeof(kwargs[:runtype]) == NoFileRun
             # early return for now
             return nothing
         end
@@ -2125,7 +2125,7 @@ function create_eval_data!(gvars)
         for line in eachline(file)
             splitedline = split(line)
             daynreval = parse(Int, popfirst!(splitedline))
-            daynreval += daynr1evaleval - 1  
+            daynreval += daynr1evaleval - 1
             if daynreval >= gvars[:simulation].FromDayNr
                 push!(DaynrEval, daynreval)
                 push!(CCmeanEval, parse(Float64, popfirst!(splitedline)))

--- a/src/initialsettings.jl
+++ b/src/initialsettings.jl
@@ -20,13 +20,13 @@ function check_for_keep_swc(outputs, projectinput::Vector{ProjectInputType}, fil
     filename = projectinput[1].Soil_Filename
     has_external = filename == "(External)"
 
-    if (has_external) 
+    if (has_external)
         # Note: here we use the AquaCrop version number and assume that
         # the same version can be used in finalizing the soil settings.
         soil = gvars[:soil]
         soil_layers = gvars[:soil_layers]
         compartments = gvars[:compartments]
-    elseif (filename == "(None)") 
+    elseif (filename == "(None)")
         soil = gvars[:soil]
         soil_layers = gvars[:soil_layers]
         compartments = gvars[:compartments]
@@ -34,21 +34,21 @@ function check_for_keep_swc(outputs, projectinput::Vector{ProjectInputType}, fil
         soil, soil_layers, compartments = load_profile(outputs,
             joinpath([filepaths[:prog], projectinput[1].Soil_Directory, filename]),
             gvars[:simulparam]; kwargs...)
-    end 
+    end
 
     # 3. Check if runs with KeepSWC exist
     runi = 1
     totalnrofruns = length(projectinput)
     while ((runwithkeepswc == false) & (runi <= totalnrofruns))
-        if (projectinput[runi].SWCIni_Filename == "KeepSWC") 
+        if (projectinput[runi].SWCIni_Filename == "KeepSWC")
             runwithkeepswc = true
-        end 
+        end
         runi = runi + 1
-    end 
+    end
 
-    if (runwithkeepswc == false) 
+    if (runwithkeepswc == false)
         constzrxforrun = undef_double # reset
-    end 
+    end
 
     # 4. Look for maximum root zone depth IF RunWithKeepSWC
     if (runwithkeepswc == true)
@@ -56,16 +56,16 @@ function check_for_keep_swc(outputs, projectinput::Vector{ProjectInputType}, fil
         while (runi <= totalnrofruns)
             # Obtain maximum rooting depth from the crop file
             fullfilename = joinpath([filepaths[:prog], projectinput[runi].Crop_Directory, projectinput[runi].Crop_Filename])
-        
+
             constzrxforrun = _check_for_keep_swc(kwargs[:runtype], fullfilename, soil_layers, constzrxforrun)
             runi = runi + 1
-        end 
-    end 
+        end
+    end
 
     # 5. Reload existing soil file is not necessary since we do not change any variables
 
     return runwithkeepswc, constzrxforrun
-end 
+end
 
 function check_for_keep_swc(outputs, projectinput::Vector{AbstractParametersContainer}, filepaths, gvars; kwargs...)
     return check_for_keep_swc(outputs, ProjectInputType[p for p in projectinput], filepaths, gvars; kwargs...)
@@ -77,14 +77,14 @@ function _check_for_keep_swc(runtype::NormalFileRun, fullfilename, soil_layers, 
         readline(file) # description
         versionnr = parse(Float64,strip(readline(file))[1:4])
         for i in 1:34
-            readline(file) 
-        end 
+            readline(file)
+        end
         zrni = parse(Float64,strip(readline(file))[1:6])
         zrxi = parse(Float64,strip(readline(file))[1:6])
         zrsoili = root_max_in_soil_profile(zrxi, soil_layers)
-        if (zrsoili > constzrxforrun) 
+        if (zrsoili > constzrxforrun)
             ret[1] = zrsoili
-        end 
+        end
     end
     return ret[1]
 end
@@ -94,9 +94,9 @@ function _check_for_keep_swc(runtype::T, fullfilename, soil_layers, constzrxforr
     aux = TOML.parsefile(fullfilename)
     zrxi = aux["crop"]["RootMax"]
     zrsoili = root_max_in_soil_profile(zrxi, soil_layers)
-    if (zrsoili > constzrxforrun) 
+    if (zrsoili > constzrxforrun)
         ret[1] = zrsoili
-    end 
+    end
     return ret[1]
 end
 
@@ -129,11 +129,11 @@ function _load_program_parameters_project_plugin!(runtype::NormalFileRun, simulp
         simulparam.EvapZmax = parse(Float64,strip(readline(file))[1:6]) # maximum water extraction depth by soil evaporation [cm] soil
         simulparam.RunoffDepth = parse(Float64,strip(readline(file))[1:6]) # considered depth (m) of soil profile for calculation of mean soil water content
         i = parse(Int,strip(readline(file))[1:6])
-        if i == 1 
+        if i == 1
             simulparam.CNcorrection = true
         else
             simulparam.CNcorrection = false
-        end 
+        end
         simulparam.SaltDiff = parse(Float64,strip(readline(file))[1:6]) # salt diffusion factor (%)
         simulparam.SaltSolub = parse(Float64,strip(readline(file))[1:6]) # salt solubility (g/liter)
         simulparam.RootNrDF = parse(Float64,strip(readline(file))[1:6]) # shape factor capillary rise factor
@@ -143,12 +143,12 @@ function _load_program_parameters_project_plugin!(runtype::NormalFileRun, simulp
         simulparam.Tmin = parse(Float64,strip(readline(file))[1:6]) # Default minimum temperature (degC) if no temperature file is specified
         simulparam.Tmax = parse(Float64,strip(readline(file))[1:6]) # Default maximum temperature (degC) if no temperature file is specified
         simulparam.GDDMethod = parse(Float64,strip(readline(file))[1:6]) # Default method for GDD calculations
-        if simulparam.GDDMethod > 3 
+        if simulparam.GDDMethod > 3
             simulparam.GDDMethod = 3
-        end 
-        if simulparam.GDDMethod < 1 
+        end
+        if simulparam.GDDMethod < 1
             simulparam.GDDMethod = 1
-        end 
+        end
 
         # Rainfall
         i = parse(Int,strip(readline(file))[1:6])
@@ -158,7 +158,7 @@ function _load_program_parameters_project_plugin!(runtype::NormalFileRun, simulp
             simulparam.EffectiveRain.method = :USDA
         elseif i==2
             simulparam.EffectiveRain.method = :Percentage
-        end 
+        end
 
         simulparam.EffectiveRain.PercentEffRain = parse(Float64,strip(readline(file))[1:6]) # IF Method is Percentage
         simulparam.EffectiveRain.ShowersInDecade = parse(Float64,strip(readline(file))[1:6])# For estimation of surface run-off
@@ -168,7 +168,7 @@ function _load_program_parameters_project_plugin!(runtype::NormalFileRun, simulp
 end
 
 function _load_program_parameters_project_plugin!(runtype::T, simulparam::RepParam, auxparfile) where T<:TomlFileRun
-    load_gvars_from_toml!(simulparam, auxparfile) 
+    load_gvars_from_toml!(simulparam, auxparfile)
     return nothing
 end
 
@@ -183,16 +183,16 @@ function check_files_in_project!(fileok::RepFileOK, allok, input::ProjectInputTy
 
     function check_file(directory, filename)
         # sets allok to false if expected file does not exist.
-        if (filename != "(None)") 
-            if !isfile(joinpath([parentdir, directory, filename])) 
+        if (filename != "(None)")
+            if !isfile(joinpath([parentdir, directory, filename]))
                 allok[1] = false
                 fileok_tmp = false
             else
                 fileok_tmp = true
-            end 
+            end
         else
             fileok_tmp = true
-        end 
+        end
         return fileok_tmp
     end
     # Check the 14 files
@@ -219,10 +219,10 @@ function check_files_in_project!(fileok::RepFileOK, allok, input::ProjectInputTy
     fileok_tmp = check_file(input.Soil_Directory, input.Soil_Filename)
     fileok.Soil_Filename = fileok_tmp
 
-    if (input.SWCIni_Filename != "KeepSWC") 
+    if (input.SWCIni_Filename != "KeepSWC")
         fileok_tmp = check_file(input.SWCIni_Directory, input.SWCIni_Filename)
         fileok.SWCIni_Filename = fileok_tmp
-    end 
+    end
 
     fileok_tmp = check_file(input.OffSeason_Directory, input.OffSeason_Filename)
     fileok.OffSeason_Filename = fileok_tmp
@@ -268,7 +268,7 @@ function _initialize_project_input(runtype::NormalFileRun, filename, parentdir; 
             # 1. Climate
             self.Climate_Info = strip(readline(file))
             self.Climate_Filename = strip(readline(file))
-            self.Climate_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Climate_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 1.1 Temperature
             self.Temperature_Info = strip(readline(file))
@@ -278,61 +278,61 @@ function _initialize_project_input(runtype::NormalFileRun, filename, parentdir; 
             # 1.2 ETo
             self.ETo_Info = strip(readline(file))
             self.ETo_Filename = strip(readline(file))
-            self.ETo_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.ETo_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 1.3 Rain
             self.Rain_Info = strip(readline(file))
             self.Rain_Filename = strip(readline(file))
-            self.Rain_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Rain_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 1.4 CO2
             self.CO2_Info = strip(readline(file))
             self.CO2_Filename = strip(readline(file))
-            self.CO2_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.CO2_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 2. Calendar
             self.Calendar_Info = strip(readline(file))
             self.Calendar_Filename = strip(readline(file))
-            self.Calendar_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Calendar_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 3. Crop
             self.Crop_Info = strip(readline(file))
             self.Crop_Filename = strip(readline(file))
-            self.Crop_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Crop_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             self.Irrigation_Info = strip(readline(file))
             self.Irrigation_Filename = strip(readline(file))
-            self.Irrigation_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Irrigation_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 5. Field Management
             self.Management_Info = strip(readline(file))
             self.Management_Filename = strip(readline(file))
-            self.Management_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Management_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 6. Soil Profile
             self.Soil_Info = strip(readline(file))
             self.Soil_Filename = strip(readline(file))
-            self.Soil_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Soil_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 7. GroundWater
             self.GroundWater_Info = strip(readline(file))
             self.GroundWater_Filename = strip(readline(file))
-            self.GroundWater_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.GroundWater_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 8. Initial conditions
             self.SWCIni_Info = strip(readline(file))
             self.SWCIni_Filename = strip(readline(file))
-            self.SWCIni_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.SWCIni_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 9. Off-season conditions
             self.OffSeason_Info = strip(readline(file))
             self.OffSeason_Filename = strip(readline(file))
-            self.OffSeason_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.OffSeason_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             # 10. Field data
             self.Observations_Info = strip(readline(file))
             self.Observations_Filename = strip(readline(file))
-            self.Observations_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"") 
+            self.Observations_Directory = replace(strip(readline(file)),"'"=>"","."=>"","/"=>"")
 
             push!(projectinput, self)
         end
@@ -366,10 +366,10 @@ function initialize_settings(outputs, filepaths; kwargs...)
     # do not change soil.RootMax like in global.f90:SaveProfile:4045 since it will be taken care later
 
     # if usedefaultsoilfile  (this is always true)
-    if typeof(kwargs[:runtype]) == NormalFileRun 
+    if typeof(kwargs[:runtype]) == NormalFileRun
         filename = joinpath([test_dir, "SIMUL", "DEFAULT.SOL"])
         # filename = joinpath(filepaths[:simul], "DEFAULT.SOL")
-    elseif typeof(kwargs[:runtype]) == TomlFileRun 
+    elseif typeof(kwargs[:runtype]) == TomlFileRun
         filename = joinpath( test_toml_dir, "gvars.toml")
         # filename = joinpath(filepaths[:simul], "gvars.toml")
     elseif typeof(kwargs[:runtype]) == NoFileRun
@@ -383,7 +383,7 @@ function initialize_settings(outputs, filepaths; kwargs...)
     #     number_soilclass!(soil_layers[1])
     #     determine_parameters_cr!(soil_layers[1])
     # end
-    
+
     simulation = RepSim()
     total_water_content = RepContent()
     complete_profile_description!(soil_layers, compartments, simulation, total_water_content)
@@ -401,11 +401,11 @@ function initialize_settings(outputs, filepaths; kwargs...)
 
     # 4. Field Management
     management.FertilityStress = 0
-    simulation.EffectStress = crop_stress_parameters_soil_fertility(crop.StressResponse, management.FertilityStress) 
+    simulation.EffectStress = crop_stress_parameters_soil_fertility(crop.StressResponse, management.FertilityStress)
 
     sumwabal = RepSum()
     previoussum = RepSum()
-    
+
     # 5. Climate
     # 5.6 Set Climate and Simulation Period
     crop.DayN = crop.Day1 + crop.DaysToHarvest - 1
@@ -515,12 +515,12 @@ function initialize_settings(outputs, filepaths; kwargs...)
     setparameter!(float_parameters, :ecdrain, undef_double)
     setparameter!(float_parameters, :eact, 0.0)
     setparameter!(float_parameters, :epot, 0.0)
-    setparameter!(float_parameters, :tactweedinfested, 0.0) 
-    setparameter!(float_parameters, :saltinfiltr, undef_double) 
-    setparameter!(float_parameters, :ccitopearlysen, undef_double) 
-    setparameter!(float_parameters, :weedrci, undef_double) 
-    setparameter!(float_parameters, :cciactualweedinfested, undef_double) 
-    setparameter!(float_parameters, :zeval, undef_double) 
+    setparameter!(float_parameters, :tactweedinfested, 0.0)
+    setparameter!(float_parameters, :saltinfiltr, undef_double)
+    setparameter!(float_parameters, :ccitopearlysen, undef_double)
+    setparameter!(float_parameters, :weedrci, undef_double)
+    setparameter!(float_parameters, :cciactualweedinfested, undef_double)
+    setparameter!(float_parameters, :zeval, undef_double)
 
 
     symbol_parameters = ParametersContainer(Symbol)
@@ -574,7 +574,7 @@ function initialize_settings(outputs, filepaths; kwargs...)
     setparameter!(bool_parameters, :part2Eval, false)
     setparameter!(bool_parameters, :out8Irri, false)
 
-    
+
 
     array_parameters = ParametersContainer(Vector{Float64})
     setparameter!(array_parameters, :Tmin, Float64[])
@@ -606,11 +606,11 @@ function initialize_settings(outputs, filepaths; kwargs...)
         setparameter!(string_parameters, :prof_file, "DEFAULT.SOL")
         setparameter!(string_parameters, :crop_file, "DEFAULT.CRO")
         setparameter!(string_parameters, :CO2_file, "MaunaLoa.CO2")
-    elseif typeof(kwargs[:runtype]) == TomlFileRun 
+    elseif typeof(kwargs[:runtype]) == TomlFileRun
         setparameter!(string_parameters, :prof_file, "gvars.toml")
         setparameter!(string_parameters, :crop_file, "gvars.toml")
         setparameter!(string_parameters, :CO2_file, "MaunaLoaCO2.csv")
-    elseif typeof(kwargs[:runtype]) == NoFileRun 
+    elseif typeof(kwargs[:runtype]) == NoFileRun
         setparameter!(string_parameters, :prof_file, "")
         setparameter!(string_parameters, :crop_file, "")
         setparameter!(string_parameters, :CO2_file, "")
@@ -676,7 +676,7 @@ function crop_stress_parameters_soil_fertility(cropsresp::RepShapes, stresslevel
     # decline canopy growth coefficient (cgc)
     pulactual = 0
     ksi = ks_any(stresslevel/100, pulactual, pllactual, cropsresp.ShapeCGC)
-    stressout.RedCGC = round(Int,(1-ksi)*100)      
+    stressout.RedCGC = round(Int,(1-ksi)*100)
     # decline maximum canopy cover (ccx)
     pulactual = 0
     ksi = ks_any(stresslevel/100, pulactual, pllactual, cropsresp.ShapeCCX)
@@ -693,7 +693,7 @@ function crop_stress_parameters_soil_fertility(cropsresp::RepShapes, stresslevel
     ksi = 1
     stressout.RedKsSto = round(Int, (1-ksi)*100)
     return stressout
-end 
+end
 
 """
     ksval = ks_any(wrel, pulactual, pllactual, shapefactor)
@@ -703,29 +703,29 @@ global.f90:KsAny:2628
 function ks_any(wrel, pulactual, pllactual, shapefactor)
     pulactual_local = pulactual
 
-    if (pllactual - pulactual_local) < 0.0001 
+    if (pllactual - pulactual_local) < 0.0001
         pulactual_local = pllactual - 0.0001
-    end 
+    end
 
     prelativellul = (wrel - pulactual_local)/(pllactual - pulactual_local)
 
-    if prelativellul <= 0 
+    if prelativellul <= 0
         ksval = 1
-    elseif prelativellul >= 1 
+    elseif prelativellul >= 1
         ksval = 0
     else
         if round(Int,10*shapefactor) == 0  # straight line
             ksval = 1 - (exp(prelativellul*0.01)-1)/(exp(0.01)-1)
         else
             ksval = 1 - (exp(prelativellul*shapefactor)-1)/(exp(shapefactor)-1)
-        end 
-        if ksval > 1 
+        end
+        if ksval > 1
             ksval = 1
-        end 
-        if ksval < 0 
+        end
+        if ksval < 0
             ksval = 0
-        end 
-    end 
+        end
+    end
     return ksval
 end
 
@@ -736,34 +736,34 @@ global.f90:CompleteCropDescription:5661
 """
 function complete_crop_description!(crop::RepCrop, simulation::RepSim, management::RepManag)
     if ((crop.subkind == :Vegetative) |
-        (crop.subkind == :Forage)) 
-        if (crop.DaysToHIo > 0) 
+        (crop.subkind == :Forage))
+        if (crop.DaysToHIo > 0)
             if (crop.DaysToHIo > crop.DaysToHarvest)
                 crop.dHIdt = crop.HI/crop.DaysToHarvest
             else
                 crop.dHIdt = crop.HI/crop.DaysToHIo
-            end 
-            if (crop.dHIdt > 100) 
+            end
+            if (crop.dHIdt > 100)
                 crop.dHIdt = 100
-            end 
+            end
         else
             crop.dHIdt = 100
-        end 
+        end
     else
         #  grain or tuber crops
-        if (crop.DaysToHIo > 0) 
+        if (crop.DaysToHIo > 0)
             crop.dHIdt = crop.HI/crop.DaysToHIo
         else
             crop.dHIdt = undef_double
         end
     end
 
-    if (crop.ModeCycle == :CalendarDays) 
+    if (crop.ModeCycle == :CalendarDays)
         crop.DaysToCCini = time_to_cc_ini(crop.Planting, crop.PlantingDens, crop.SizeSeedling,
                                        crop.SizePlant, crop.CCx, crop.CGC)
         crop.DaysToFullCanopy = days_to_reach_cc_with_given_cgc(0.98*crop.CCx, crop.CCo, crop.CCx,
                                                           crop.CGC, crop.DaysToGermination)
-        if (management.FertilityStress != 0) 
+        if (management.FertilityStress != 0)
             fertstress = management.FertilityStress
             daystofullcanopy, RedCGC_temp, RedCCX_temp, fertstress = time_to_max_canopy_sf(crop.CCo, crop.CGC, crop.CCx,
                               crop.DaysToGermination,
@@ -782,8 +782,8 @@ function complete_crop_description!(crop::RepCrop, simulation::RepSim, managemen
             simulation.EffectStress.RedCCX = RedCCX_temp
             crop.DaysToFullCanopySF = daystofullcanopy
         else
-            crop.DaysToFullCanopySF = crop.DaysToFullCanopy 
-        end 
+            crop.DaysToFullCanopySF = crop.DaysToFullCanopy
+        end
     else
         crop.GDDaysToCCini = time_to_cc_ini(crop.Planting, crop.PlantingDens, crop.SizeSeedling,
                                          crop.SizePlant, crop.CCx, crop.GDDCGC)
@@ -791,10 +791,10 @@ function complete_crop_description!(crop::RepCrop, simulation::RepSim, managemen
                                          crop.SizePlant, crop.CCx, crop.CGC)
         crop.GDDaysToFullCanopy = days_to_reach_cc_with_given_cgc(0.98*crop.CCx, crop.CCo, crop.CCx,
                                                           crop.GDDCGC, crop.GDDaysToGermination)
-    end 
+    end
 
     cgcisgiven = true # required to adjust crop.daystofullcanopy (does not exist)
-    length123, stlength, length12, cgcval = determine_length_growth_stages(crop.CCo, crop.CCx, 
+    length123, stlength, length12, cgcval = determine_length_growth_stages(crop.CCo, crop.CCx,
                                                             crop.CDC, crop.DaysToGermination,
                                                             crop.DaysToHarvest, cgcisgiven,
                                                             crop.DaysToCCini, crop.Planting,
@@ -808,27 +808,27 @@ function complete_crop_description!(crop::RepCrop, simulation::RepSim, managemen
     crop.CCoAdjusted = crop.CCo
     crop.CCxAdjusted = crop.CCx
     crop.CCxWithered = crop.CCx
-end 
+end
 
 """
-    length123, stlength, length12, cgcval = determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength, 
-                                                                        cgcgiven, thedaystoccini, theplanting, 
+    length123, stlength, length12, cgcval = determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength,
+                                                                        cgcgiven, thedaystoccini, theplanting,
                                                                         length123, stlength, length12, cgcval)
 
 global.f90:DetermineLengthGrowthStages:1661
 """
-function determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength, 
-                                     cgcgiven, thedaystoccini, theplanting, 
+function determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength,
+                                     cgcgiven, thedaystoccini, theplanting,
                                      length123, stlength, length12, cgcval)
     #OJO this function might have problems
-    if (length123 < length12) 
+    if (length123 < length12)
         length123 = length12
-    end 
+    end
 
     # 1. Initial and 2. Crop Development stage
     # CGC is given and Length12 is already adjusted to it
     # OR Length12 is given and CGC has to be determined
-    if ((ccoval >= ccxval) | (length12 <= l0)) 
+    if ((ccoval >= ccxval) | (length12 <= l0))
         length12 = 0
         stlength[1] = 0
         stlength[2] = 0
@@ -837,34 +837,34 @@ function determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength,
         if (!cgcgiven)  # length12 is given and cgc has to be determined
             cgcval = log((0.25*ccxval/ccoval)/(1-0.98))/(length12-l0)
             # check if cgc < maximum value (0.40) and adjust length12 if required
-            if (cgcval > 0.40) 
+            if (cgcval > 0.40)
                 cgcval = 0.40
                 ccxval_scaled = 0.98*ccxval
-                length12 = days_to_reach_cc_with_given_cgc(ccxval_scaled , ccoval, 
+                length12 = days_to_reach_cc_with_given_cgc(ccxval_scaled , ccoval,
                                                              ccxval, cgcval, l0)
-                if (length123 < length12) 
+                if (length123 < length12)
                     length123 = length12
-                end 
-            end 
-        end 
+                end
+            end
+        end
         # find stlength[1]
         cctoreach = 0.10
-        stlength[1] = days_to_reach_cc_with_given_cgc(cctoreach, ccoval, ccxval, 
+        stlength[1] = days_to_reach_cc_with_given_cgc(cctoreach, ccoval, ccxval,
                                                                     cgcval, l0)
         # find stlength[2]
         stlength[2] = length12 - stlength[1]
-    end 
+    end
     l12adj = length12
 
     # adjust Initial and Crop Development stage, in case crop starts as regrowth
-    if (theplanting == :Regrowth) 
-        if (thedaystoccini == undef_int) 
+    if (theplanting == :Regrowth)
+        if (thedaystoccini == undef_int)
             # maximum canopy cover is already reached at start season
             l12adj = 0
             stlength[1] = 0
             stlength[2] = 0
         else
-            if (thedaystoccini == 0) 
+            if (thedaystoccini == 0)
                 # start at germination
                 l12adj = length12 - l0
                 stlength[1] = stlength[1] - l0
@@ -872,13 +872,13 @@ function determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength,
                 # start after germination
                 l12adj = length12 - (l0 + thedaystoccini)
                 stlength[1] = stlength[1] - (l0 + thedaystoccini)
-            end 
-            if (stlength[1] < 0) 
+            end
+            if (stlength[1] < 0)
                 stlength[1] = 0
             end
             stlength[2] = l12adj - stlength[1]
-        end 
-    end 
+        end
+    end
 
     # 3. Mid season stage
     stlength[3] = length123 - l12adj
@@ -887,25 +887,25 @@ function determine_length_growth_stages(ccoval, ccxval, cdcval, l0, totallength,
     stlength[4] = length_canopy_decline(ccxval, cdcval)
 
     # final adjustment
-    if (stlength[1] > totallength) 
+    if (stlength[1] > totallength)
         stlength[1] = totallength
         stlength[2] = 0
         stlength[3] = 0
         stlength[4] = 0
     else
-        if ((stlength[1]+stlength[2]) > totallength) 
+        if ((stlength[1]+stlength[2]) > totallength)
             stlength[2] = totallength - stlength[1]
             stlength[3] = 0
             stlength[4] = 0
         else
-            if ((stlength[1]+stlength[2]+stlength[3]) > totallength) 
+            if ((stlength[1]+stlength[2]+stlength[3]) > totallength)
                 stlength[3] = totallength - stlength[1] - stlength[2]
                 stlength[4] = 0
-            elseif ((stlength[1]+stlength[2]+stlength[3]+stlength[4]) > totallength) 
+            elseif ((stlength[1]+stlength[2]+stlength[3]+stlength[4]) > totallength)
                 stlength[4] = totallength - stlength[1] - stlength[2] - stlength[3]
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     return length123, stlength, length12, cgcval
 end
@@ -917,14 +917,14 @@ global.f90:LengthCanopyDecline:1856
 """
 function length_canopy_decline(ccx, cdc)
     nd = 0
-    if (ccx > 0) 
-        if (cdc <= eps(1.0)) 
+    if (ccx > 0)
+        if (cdc <= eps(1.0))
             nd = undef_int
         else
             nd = round(Int, (((ccx+2.29)/(cdc*3.33))*log(1 + 1/0.05) + 0.50))
                          # + 0.50 to guarantee that cc is zero
-        end 
-    end 
+        end
+    end
     return nd
 end
 
@@ -934,19 +934,19 @@ end
 global.f90:TimeToMaxCanopySF:2107
 """
 function time_to_max_canopy_sf(cco, cgc, ccx, l0, l12, l123, ltoflor, lflor, determinantcrop, l12sf, redcgc, redccx, classsf)
-    if ((classsf == 0) | ((redccx == 0) & (redcgc == 0))) 
+    if ((classsf == 0) | ((redccx == 0) & (redcgc == 0)))
         l12sf = l12
     else
         cctoreach = 0.98*(1-redccx/100)*ccx
         l12sf = days_to_reach_cc_with_given_cgc(cctoreach, cco, ((1-redccx/100)*ccx), (cgc*(1-(redcgc)/100)), l0)
         # determine l12sfmax
-        if (determinantcrop) 
+        if (determinantcrop)
             l12sfmax = ltoflor + round(Int, lflor/2)
         else
             l12sfmax = l123
         end
         # check for l12sfmax
-        if (l12sf > l12sfmax) 
+        if (l12sf > l12sfmax)
             # full canopy cannot be reached in potential period for vegetative growth
             # classsf := undef_int; ! switch to user defined soil fertility
             # 1. increase cgc(soil fertility)
@@ -960,8 +960,8 @@ function time_to_max_canopy_sf(cco, cgc, ccx, l0, l12, l123, ltoflor, lflor, det
                 cctoreach = 0.98*(1-redccx/100)*ccx
                 l12sf = days_to_reach_cc_with_given_cgc(cctoreach, cco, ((1-redccx/100)*ccx), (cgc*(1-(redcgc)/100)), l0)
             end
-        end 
-    end 
+        end
+    end
     return l12sf, redcgc, redccx, classsf
 end
 
@@ -972,29 +972,29 @@ global.f90:DaysToReachCCWithGivenCGC:1826
 """
 function days_to_reach_cc_with_given_cgc(cctoreach, ccoval, ccxval, cgcval, l0)
     cctoreach_local = cctoreach
-    if ((ccoval > cctoreach_local) | (ccoval >= ccxval)) 
+    if ((ccoval > cctoreach_local) | (ccoval >= ccxval))
         l = 0
     else
-        if (cctoreach_local > (0.98*ccxval)) 
+        if (cctoreach_local > (0.98*ccxval))
             cctoreach_local = 0.98*ccxval
-        end 
-        if (cctoreach_local <= ccxval/2) 
+        end
+        if (cctoreach_local <= ccxval/2)
             l = log(cctoreach_local/ccoval)/cgcval
         else
             l = log((0.25*ccxval*ccxval/ccoval)/(ccxval-cctoreach_local))/cgcval
         end
-    end 
+    end
     daystoresult = l0 + round(Int, l)
     return daystoresult
 end
 
 """
-    elapsedtime = time_to_cc_ini(theplantingtype, thecropplantingdens, 
+    elapsedtime = time_to_cc_ini(theplantingtype, thecropplantingdens,
                           thesizeseedling, thesizeplant, thecropccx, thecropcgc)
 
 global.f90:TimeToCCini:1771
 """
-function time_to_cc_ini(theplantingtype, thecropplantingdens, 
+function time_to_cc_ini(theplantingtype, thecropplantingdens,
                           thesizeseedling, thesizeplant, thecropccx, thecropcgc)
     if ((theplantingtype == :Seed) | (theplantingtype == :Transplant) |
         (thesizeseedling >= thesizeplant))
@@ -1002,13 +1002,13 @@ function time_to_cc_ini(theplantingtype, thecropplantingdens,
     else
         thecropcco = (thecropplantingdens/10000) * (thesizeseedling/10000)
         thecropccini = (thecropplantingdens/10000) * (thesizeplant/10000)
-        if (thecropccini >= (0.98*thecropccx)) 
+        if (thecropccini >= (0.98*thecropccx))
             elapsedtime = undef_int
         else
-            elapsedtime = days_to_reach_cc_with_given_cgc(thecropccini, thecropcco, 
+            elapsedtime = days_to_reach_cc_with_given_cgc(thecropccini, thecropcco,
                                                     thecropccx, thecropcgc, 0)
-        end 
-    end 
+        end
+    end
     return elapsedtime
 end
 
@@ -1027,16 +1027,16 @@ function root_max_in_soil_profile(zmaxcrop, soil_layers::Vector{SoilLayerIndivid
         layi = layi + 1
 
         if ((soil_layers[layi].Penetrability < 100) &
-            (round(Int, zsoil*1000) < round(Int, zmaxcrop*1000))) 
+            (round(Int, zsoil*1000) < round(Int, zmaxcrop*1000)))
             zmax = undef_double
-        end 
+        end
 
         zsoil += soil_layers[layi].Thickness
-    end 
+    end
 
-    if (zmax < 0) 
+    if (zmax < 0)
         zmax = zr_adjusted_to_restrictive_layers(zmaxcrop, soil_layers)
-    end 
+    end
 
     return zmax
 end
@@ -1073,7 +1073,7 @@ function zr_adjusted_to_restrictive_layers(zrin, soil_layers::Vector{SoilLayerIn
 
         if ((layi == nrsoil_layers) |
             (soil_layers[layi].Penetrability == 0) |
-            (round(Int, zrtest*10000) <= round(Int, zsoil*10000))) 
+            (round(Int, zrtest*10000) <= round(Int, zsoil*10000)))
             # no root expansion in layer
             zrout = zrtest
             theend = true
@@ -1084,18 +1084,18 @@ function zr_adjusted_to_restrictive_layers(zrin, soil_layers::Vector{SoilLayerIn
             zsoil += zsoil + soil_layers[layi].Thickness
             deltaz = soil_layers[layi].Thickness
         end
-    end 
+    end
     return zrout
 end
 
 """
-    complete_profile_description!(soil_layers::Vector{SoilLayerIndividual}, 
-            compartments::Vector{CompartmentIndividual}, simulation::RepSim, total_water_content::RepContent)  
+    complete_profile_description!(soil_layers::Vector{SoilLayerIndividual},
+            compartments::Vector{CompartmentIndividual}, simulation::RepSim, total_water_content::RepContent)
 
 global.f90:CompleteProfileDescription:7598
 """
-function complete_profile_description!(soil_layers::Vector{SoilLayerIndividual}, 
-            compartments::Vector{CompartmentIndividual}, simulation::RepSim, total_water_content::RepContent)  
+function complete_profile_description!(soil_layers::Vector{SoilLayerIndividual},
+            compartments::Vector{CompartmentIndividual}, simulation::RepSim, total_water_content::RepContent)
     nrcompartments = length(compartments)
     nrsoil_layers = length(soil_layers)
 
@@ -1104,18 +1104,18 @@ function complete_profile_description!(soil_layers::Vector{SoilLayerIndividual},
 
     for compi in 1:nrcompartments
         compartments[compi].Theta = soil_layers[compartments[compi].Layer].FC/100
-        compartments[compi].FCadj = soil_layers[compartments[compi].Layer].FC 
+        compartments[compi].FCadj = soil_layers[compartments[compi].Layer].FC
 
         simulation.ThetaIni[compi] = compartments[compi].Theta
 
-        soil_layers[compartments[compi].Layer].WaterContent += 
+        soil_layers[compartments[compi].Layer].WaterContent +=
             simulation.ThetaIni[compi]*100 * 10*compartments[compi].Thickness
     end
 
     total = 0
     for layeri in 1:nrsoil_layers
         total += soil_layers[layeri].WaterContent
-    end 
+    end
     total_water_content.BeginDay = total
 
     # global.f90:DeclareInitialCondAtFCandNoSalt:1186
@@ -1126,12 +1126,12 @@ function complete_profile_description!(soil_layers::Vector{SoilLayerIndividual},
         simulation.IniSWC.Loc[layeri] = soil_layers[layeri].Thickness
         simulation.IniSWC.VolProc[layeri] = soil_layers[layeri].FC
         simulation.IniSWC.SaltECe[layeri] = 0
-    end 
+    end
     return nothing
-end 
+end
 
-function complete_profile_description!(soil_layers::Vector{AbstractParametersContainer}, 
-            compartments::Vector{AbstractParametersContainer}, simulation::RepSim, total_water_content::RepContent)  
+function complete_profile_description!(soil_layers::Vector{AbstractParametersContainer},
+            compartments::Vector{AbstractParametersContainer}, simulation::RepSim, total_water_content::RepContent)
     complete_profile_description!(SoilLayerIndividual[s for s in soil_layers], CompartmentIndividual[c for c in compartments], simulation, total_water_content)
     return nothing
 end
@@ -1148,29 +1148,29 @@ function designate_soillayer_to_compartments!(compartments::Vector{CompartmentIn
     depthi = 0
     layeri = 1
     compi = 1
-    
+
     outer_loop = true
-    while outer_loop 
+    while outer_loop
         depth = depth + soil_layers[layeri].Thickness
         inner_loop = true
         finished = false
         while inner_loop
             depthi = depthi + compartments[compi].Thickness/2
 
-            if (depthi <= depth) 
+            if (depthi <= depth)
                 compartments[compi].Layer = layeri
                 nextlayer = false
-                depthi = depthi + compartments[compi].Thickness/2 
+                depthi = depthi + compartments[compi].Thickness/2
                 compi = compi + 1
                 finished = (compi > nrcompartments)
             else
-                depthi = depthi - compartments[compi].Thickness/2 
+                depthi = depthi - compartments[compi].Thickness/2
                 nextlayer = true
                 layeri = layeri + 1
                 finished = (layeri > nrsoil_layers)
-            end 
+            end
 
-            if (finished | nextlayer) 
+            if (finished | nextlayer)
                 inner_loop = false
             end
         end
@@ -1182,12 +1182,12 @@ function designate_soillayer_to_compartments!(compartments::Vector{CompartmentIn
 
     for i in compi:nrcompartments
         compartments[i].Layer = nrsoil_layers
-    end 
+    end
     return nothing
-end 
+end
 
-function designate_soillayer_to_compartments!(compartments::Vector{AbstractParametersContainer}, 
-    soil_layers::Vector{AbstractParametersContainer})  
+function designate_soillayer_to_compartments!(compartments::Vector{AbstractParametersContainer},
+    soil_layers::Vector{AbstractParametersContainer})
     designate_soillayer_to_compartments!( CompartmentIndividual[c for c in compartments], SoilLayerIndividual[s for s in soil_layers])
     return nothing
 end
@@ -1247,14 +1247,14 @@ function _load_profile(runtype::NormalFileRun, outputs, filepath; kwargs...)
             soillayer.CRa = cra_temp
             crb_temp = parse(Float64,popfirst!(splitedline))
             soillayer.CRb = crb_temp
-            description_temp = join(splitedline, " ") 
+            description_temp = join(splitedline, " ")
             soillayer.Description = description_temp
             gravelv_temp = from_gravelmass_to_gravelvol(SAT_temp, gravelm_temp)
             soillayer.GravelVol = gravelv_temp
             push!(soil_layers, soillayer)
         end
     end
-    return soil, soil_layers 
+    return soil, soil_layers
 end
 
 function _load_profile(runtype::T, outputs, filepath; kwargs...) where T<:TomlFileRun
@@ -1290,7 +1290,7 @@ function load_profile_processing!(soil::RepSoil, soil_layers::Vector{SoilLayerIn
 
     for i in eachindex(soil_layers)
         soillayer = soil_layers[i]
-        
+
         # determine drainage coefficient
         tau = tau_from_ksat(soillayer.InfRate)
         soillayer.tau = tau
@@ -1337,7 +1337,7 @@ function determine_nrand_thickness_compartments!(compartments::Vector{Compartmen
     totaldepthl = 0
     for i in eachindex(soil_layers)
         totaldepthl += soil_layers[i].Thickness
-    end 
+    end
     totaldepthc = 0
     nrcompartments = 0
     loopi = true
@@ -1349,7 +1349,7 @@ function determine_nrand_thickness_compartments!(compartments::Vector{Compartmen
             compartment.Thickness = compdefthick
         else
             compartment.Thickness = deltaz
-        end 
+        end
         totaldepthc += compartment.Thickness
         push!(compartments, compartment)
         if ((nrcompartments == max_no_compartments) | (abs(totaldepthc - totaldepthl) < 0.0001))
@@ -1374,52 +1374,52 @@ function calculate_salt_mobility!(soillayer::SoilLayerIndividual, saltdiffusion)
     UL = soillayer.UL * 100 # upper limit in VOL% of SC cell
 
     # 1. convert Macro (vol%) in SaltCelNumber
-    if (Macro > UL) 
-        CelMax = soillayer.SCP1 
+    if (Macro > UL)
+        CelMax = soillayer.SCP1
     else
         CelMax = round(Int, (Macro/UL)*soillayer.SC)
-    end 
+    end
 
-    if (CelMax <= 0) 
+    if (CelMax <= 0)
         CelMax = 1
     end
 
     # 2. find a and b
-    if (Mix < 0.5) 
+    if (Mix < 0.5)
         a = Mix * 2
         b = exp(10*(0.5-Mix)*log(10))
     else
         a = 2 * (1 - Mix)
         b = exp(10*(Mix-0.5)*log(10))
-    end 
+    end
 
     # 3. calculate mobility for cells = 1 to Macro
     for i in 1:CelMax-1
         xi = i/(CelMax-1)
-        if (Mix > 0) 
-            if (Mix < 0.5) 
+        if (Mix > 0)
+            if (Mix < 0.5)
                 yi = exp(log(a)+xi*log(b))
                 Mobil[i] = (yi-a)/(a*b-a)
             elseif ((Mix >= 0.5 - eps(0.0)) & (Mix <= 0.5 + eps(0.0)))
                 Mobil[i] = xi
-            elseif (Mix < 1) 
+            elseif (Mix < 1)
                 yi = exp(log(a)+(1-xi)*log(b))
                 Mobil[i] = 1 - (yi-a)/(a*b-a)
             else
                 Mobil[i] = 1
-            end 
+            end
         else
             Mobil[i] = 0
-        end 
-    end 
+        end
+    end
 
     # 4. Saltmobility between Macro and SAT
-    for i in CelMax:soillayer.SCP1 
+    for i in CelMax:soillayer.SCP1
         Mobil[i] = 1
-    end 
+    end
 
     return nothing
-end 
+end
 
 """
     tau = tau_from_ksat(ksat)
@@ -1427,18 +1427,18 @@ end
 global.f90:TauFromKsat:1906
 """
 function tau_from_ksat(ksat)
-    if (abs(ksat) < eps(1.0)) 
+    if (abs(ksat) < eps(1.0))
         tau = 0
     else
         tautemp = round(Int,100.0*0.0866*exp(0.35*log(ksat)))
-        if (tautemp < 0) 
+        if (tautemp < 0)
             tautemp = 0
-        end 
-        if (tautemp > 100) 
+        end
+        if (tautemp > 100)
             tautemp = 100
-        end 
+        end
         tau = tautemp/100.0
-    end 
+    end
     return tau
 end
 
@@ -1451,7 +1451,7 @@ global.f90:FromGravelMassToGravelVolume:1538
 """
 function from_gravelmass_to_gravelvol(porositypercent, gravelmasspercent)
     mineralbd = 2.65 # mg/m3
-    if (gravelmasspercent > 0) 
+    if (gravelmasspercent > 0)
         matrixbd = mineralbd * (1.0 - porositypercent/100.0)
         soilbd = 100.0/(gravelmasspercent/mineralbd + (100.0-gravelmasspercent)/matrixbd)
         fromgravelmasstogravelvolume = gravelmasspercent * (soilbd/mineralbd)
@@ -1468,13 +1468,13 @@ sets the soil class of soillayer considering its own data.
 
 global.f90:NumberSoilClass:1926
 """
-function number_soilclass!(soillayer::SoilLayerIndividual) 
+function number_soilclass!(soillayer::SoilLayerIndividual)
     satvolpro = soillayer.SAT
     fcvolpro = soillayer.FC
     pwpvolpro = soillayer.WP
     ksatmm = soillayer.InfRate
 
-    if (satvolpro <= 55.0) 
+    if (satvolpro <= 55.0)
         if (pwpvolpro >= 20.0)
             if ((satvolpro >= 49.0) & (fcvolpro >= 40.0))
                 numbersoilclass = 4  # silty clayey soils
@@ -1485,23 +1485,23 @@ function number_soilclass!(soillayer::SoilLayerIndividual)
             if (fcvolpro < 23.0)
                 numbersoilclass = 1 # sandy soils
             else
-                if ((pwpvolpro > 16.0) & (ksatmm < 100.0)) 
+                if ((pwpvolpro > 16.0) & (ksatmm < 100.0))
                     numbersoilclass = 3 # sandy clayey soils
                 else
-                    if ((pwpvolpro < 6.0) & (fcvolpro < 28.0) & (ksatmm >750.0)) 
+                    if ((pwpvolpro < 6.0) & (fcvolpro < 28.0) & (ksatmm >750.0))
                         numbersoilclass = 1 # sandy soils
                     else
                         numbersoilclass = 2  # loamy soils
-                    end 
-                end 
-            end 
-        end 
+                    end
+                end
+            end
+        end
     else
         numbersoilclass = 4 # silty clayey soils
-    end 
+    end
     soillayer.SoilClass = numbersoilclass
     return nothing
-end 
+end
 
 """
     determine_parameters_cr!(soillayer::SoilLayerIndividual)
@@ -1525,7 +1525,7 @@ function determine_parameters_cr!(soillayer::SoilLayerIndividual)
         elseif soilclass == 2
             aparam = -0.4986 + 9.0*ksatmm/100000.0
             bparam = -2.1320 + 0.4778*log(ksatmm)
-        elseif soilclass == 3 
+        elseif soilclass == 3
             aparam = -0.5677 - 4.0*ksatmm/100000.0
             bparam = -3.7189 + 0.5922*log(ksatmm)
         else
@@ -1588,7 +1588,7 @@ function initialize_project_filenames(outputs, filepaths; kwargs...)
     return _initialize_project_filenames(kwargs[:runtype], outputs, filepaths)
 end
 
-function _initialize_project_filenames(runtype::NormalFileRun, outputs, filepaths) 
+function _initialize_project_filenames(runtype::NormalFileRun, outputs, filepaths)
     project_filenames = String[]
 
     listprojectsfile = joinpath(filepaths[:list],"ListProjects.txt")
@@ -1648,7 +1648,7 @@ end
 
 """
     filepaths = initialize_the_program(outputs, parentdir; kwargs...)
-    
+
 Gets the file paths and the simulation parameters.
 
 startunit.f90:InitializeTheProgram:429
@@ -1659,7 +1659,7 @@ function initialize_the_program(outputs, parentdir; kwargs...)
     # the part of get_results_parameters is done when we create gvars
     # resultsparameters = get_results_parameters(outputs, filepaths[:simul]; kwargs...)
 
-    return filepaths#, resultsparameters 
+    return filepaths#, resultsparameters
 end
 
 """
@@ -1715,7 +1715,7 @@ function _get_results_parameters(runtype::NormalFileRun, outputs, path::String; 
     #startunit.f90:GetTimeAggregationResults:291
     aggregationresultsparameters = ParametersContainer(Int)
     filename_a = joinpath(path, "AggregationResults.SIM")
-    if isfile(filename_a) 
+    if isfile(filename_a)
         open(filename_a, "r") do file
             aggregationtype = strip(readline(file))[1]
             if aggregationtype == '1'
@@ -1733,7 +1733,7 @@ function _get_results_parameters(runtype::NormalFileRun, outputs, path::String; 
     #startunit.f90:GetRequestDailyResults:193
     dailyresultsparameters = ParametersContainer(Bool)
     filename_d = joinpath(path, "DailyResults.SIM")
-    if isfile(filename_d) 
+    if isfile(filename_d)
         open(filename_d, "r") do file
             for line in eachline(file)
                 if isempty(line)
@@ -1758,7 +1758,7 @@ function _get_results_parameters(runtype::NormalFileRun, outputs, path::String; 
                     setparameter!(dailyresultsparameters, :out8Irri, true)
                 end
             end
-            if ( dailyresultsparameters[:out1Wabal] | dailyresultsparameters[:out2Crop] 
+            if ( dailyresultsparameters[:out1Wabal] | dailyresultsparameters[:out2Crop]
                 | dailyresultsparameters[:out3Prof] | dailyresultsparameters[:out4Salt]
                 | dailyresultsparameters[:out5CompWC] | dailyresultsparameters[:out6CompEC]
                 | dailyresultsparameters[:out7Clim])
@@ -1772,7 +1772,7 @@ function _get_results_parameters(runtype::NormalFileRun, outputs, path::String; 
     #startunit.f90:GetRequestParticularResults:257
     particularresultsparameters = ParametersContainer(Bool)
     filename_p = joinpath(path, "ParticularResults.SIM")
-    if isfile(filename_p) 
+    if isfile(filename_p)
         open(filename_p, "r") do file
             for line in eachline(file)
                 if isempty(line)
@@ -1797,7 +1797,7 @@ end
 
 function _get_results_parameters(runtype::T, outputs, path::String; kwargs...) where T<:TomlFileRun
     filename = joinpath(path, "resultsparameters.toml")
-    return load_resultsparameters_from_toml(filename) 
+    return load_resultsparameters_from_toml(filename)
 end
 
 function _get_results_parameters(runtype::T, outputs, path::String; kwargs...) where T<:NoFileRun

--- a/src/loadsimulation.jl
+++ b/src/loadsimulation.jl
@@ -1,9 +1,9 @@
 """
-    load_simulation_project!(outputs, gvars, projectinput::ProjectInputType; kwargs...) 
+    load_simulation_project!(outputs, gvars, projectinput::ProjectInputType; kwargs...)
 
 tempprocessing.f90:LoadSimulationRunProject:2057
 """
-function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType; kwargs...) 
+function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType; kwargs...)
     # 0. Year of cultivation and Simulation and Cropping period
     gvars[:simulation].YearSeason = projectinput.Simulation_YearSeason
     gvars[:crop].Day1 = projectinput.Crop_Day1
@@ -13,20 +13,20 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
 
     # 1.1 Temperature
     if (projectinput.Temperature_Filename=="(None)") | (projectinput.Temperature_Filename=="(External)")
-        temperature_file = projectinput.Temperature_Filename 
+        temperature_file = projectinput.Temperature_Filename
         setparameter!(gvars[:bool_parameters], :temperature_file_exists, false)
     else
         _temperature_file = joinpath([projectinput.ParentDir, projectinput.Temperature_Directory, projectinput.Temperature_Filename])
         if typeof(kwargs[:runtype]) == NormalFileRun
             temperature_file = _temperature_file
             setparameter!(gvars[:bool_parameters], :temperature_file_exists, isfile(temperature_file))
-        elseif typeof(kwargs[:runtype]) == TomlFileRun 
+        elseif typeof(kwargs[:runtype]) == TomlFileRun
             temperature_file = _temperature_file[1:end-5]*".csv"
             setparameter!(gvars[:bool_parameters], :temperature_file_exists, isfile(temperature_file))
         elseif typeof(kwargs[:runtype]) == NoFileRun
             temperature_file = ""
             if haskey(kwargs, :Tmin) & haskey(kwargs, :Tmax)
-                setparameter!(gvars[:bool_parameters], :temperature_file_exists, true) 
+                setparameter!(gvars[:bool_parameters], :temperature_file_exists, true)
             end
         end
         if gvars[:bool_parameters][:temperature_file_exists]
@@ -35,32 +35,32 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         load_clim!(gvars[:temperature_record], _temperature_file;
                    nrobs=length(gvars[:array_parameters][:Tmin]),
                    str="temperature_record", kwargs...)
-    end 
+    end
     setparameter!(gvars[:string_parameters], :temperature_file, temperature_file)
 
-    # Create Temperature Reference file 
+    # Create Temperature Reference file
     if temperature_file != "(External)"
-        create_tnxreferencefile!(outputs, gvars; kwargs...) 
-    end 
+        create_tnxreferencefile!(outputs, gvars; kwargs...)
+    end
     create_tnxreference365days!(outputs, gvars; kwargs...)
 
 
     # 1.2 ETo
     if (projectinput.ETo_Filename=="(None)") | (projectinput.ETo_Filename=="(External)")
-        eto_file = projectinput.ETo_Filename 
+        eto_file = projectinput.ETo_Filename
         setparameter!(gvars[:bool_parameters], :eto_file_exists, false)
     else
         _eto_file = joinpath([projectinput.ParentDir, projectinput.ETo_Directory, projectinput.ETo_Filename])
         if typeof(kwargs[:runtype]) == NormalFileRun
             eto_file = _eto_file
             setparameter!(gvars[:bool_parameters], :eto_file_exists, isfile(eto_file))
-        elseif typeof(kwargs[:runtype]) == TomlFileRun 
+        elseif typeof(kwargs[:runtype]) == TomlFileRun
             eto_file = _eto_file[1:end-5]*".csv"
             setparameter!(gvars[:bool_parameters], :eto_file_exists, isfile(eto_file))
         elseif typeof(kwargs[:runtype]) == NoFileRun
             eto_file = ""
-            if haskey(kwargs, :ETo) 
-                setparameter!(gvars[:bool_parameters], :eto_file_exists, true) 
+            if haskey(kwargs, :ETo)
+                setparameter!(gvars[:bool_parameters], :eto_file_exists, true)
             end
         end
         if gvars[:bool_parameters][:eto_file_exists]
@@ -69,7 +69,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         load_clim!(gvars[:eto_record], _eto_file;
                    nrobs=length(gvars[:array_parameters][:ETo]),
                    str="eto_record", kwargs...)
-    end 
+    end
     setparameter!(gvars[:string_parameters], :eto_file, eto_file)
 
     # 1.3 Rain
@@ -81,13 +81,13 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         if typeof(kwargs[:runtype]) == NormalFileRun
             rain_file = _rain_file
             setparameter!(gvars[:bool_parameters], :rain_file_exists, isfile(rain_file))
-        elseif typeof(kwargs[:runtype]) == TomlFileRun 
+        elseif typeof(kwargs[:runtype]) == TomlFileRun
             rain_file = _rain_file[1:end-5]*".csv"
             setparameter!(gvars[:bool_parameters], :rain_file_exists, isfile(rain_file))
         elseif typeof(kwargs[:runtype]) == NoFileRun
             rain_file = ""
-            if haskey(kwargs, :Rain) 
-                setparameter!(gvars[:bool_parameters], :rain_file_exists, true) 
+            if haskey(kwargs, :Rain)
+                setparameter!(gvars[:bool_parameters], :rain_file_exists, true)
             end
         end
         if gvars[:bool_parameters][:rain_file_exists]
@@ -96,9 +96,9 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         load_clim!(gvars[:rain_record], _rain_file;
                    nrobs=length(gvars[:array_parameters][:Rain]),
                    str="rain_record", kwargs...)
-    end 
+    end
     setparameter!(gvars[:string_parameters], :rain_file, rain_file)
-    
+
 
     # 1.4 CO2 and Climate
     if projectinput.CO2_Filename != "(None)"
@@ -122,7 +122,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         gvars[:crop_file_set].GDDaysToHarvest = gvars[:crop].GDDaysToHarvest
     else
         gvars[:crop_file_set].GDDaysFromSenescenceToEnd = undef_int
-        gvars[:crop_file_set].GDDaysToHarvest = undef_int 
+        gvars[:crop_file_set].GDDaysToHarvest = undef_int
     end
     # maximum rooting depth in given soil profile
     gvars[:soil].RootMax = root_max_in_soil_profile(gvars[:crop].RootMax, gvars[:soil_layers])
@@ -135,44 +135,44 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         # adjust length of season
         gvars[:crop].DaysToHarvest = gvars[:crop].DayN - gvars[:crop].Day1 + 1
         adjust_crop_file_parameters!(gvars)
-    end 
+    end
     adjust_calendar_crop!(gvars)
     complete_crop_description!(gvars[:crop], gvars[:simulation], gvars[:management])
     # Onset.Off := true;
     clim_file = gvars[:string_parameters][:clim_file]
-    if clim_file=="(None)" 
+    if clim_file=="(None)"
         # adjusting Crop.Day1 and Crop.DayN to ClimFile
         adjust_crop_year_to_climfile!(gvars[:crop], clim_file, gvars[:clim_record])
     else
         gvars[:crop].DayN = gvars[:crop].Day1 + gvars[:crop].DaysToHarvest - 1
-    end 
+    end
 
     # adjusting ClimRecord.'TO' for undefined year with 365 days
-    if (clim_file != "(None)") & (gvars[:clim_record].FromY == 1901) & (gvars[:clim_record].NrObs==365) 
+    if (clim_file != "(None)") & (gvars[:clim_record].FromY == 1901) & (gvars[:clim_record].NrObs==365)
         adjust_climrecord_to!(gvars[:clim_record], gvars[:crop].DayN)
-    end 
+    end
     # adjusting simulation period
     adjust_simperiod!(gvars, projectinput)
 
     # 4. Irrigation
-    if projectinput.Irrigation_Filename == "(None)" 
+    if projectinput.Irrigation_Filename == "(None)"
         irri_file = projectinput.Irrigation_Filename
         no_irrigation!(gvars)
     else
         irri_file = joinpath([projectinput.ParentDir, projectinput.Irrigation_Directory, projectinput.Irrigation_Filename])
         load_irri_schedule_info!(gvars, irri_file)
-    end 
+    end
     setparameter!(gvars[:string_parameters], :irri_file, irri_file)
 
     # 5. Field Management
-    if projectinput.Management_Filename == "(None)" 
+    if projectinput.Management_Filename == "(None)"
         man_file = projectinput.Management_Filename
     else
         man_file = joinpath([projectinput.ParentDir, projectinput.Management_Directory, projectinput.Management_Filename])
         load_management!(gvars, man_file; kwargs...)
         # reset canopy development to soil fertility
         daystofullcanopy, RedCGC_temp, RedCCX_temp, fertstress = time_to_max_canopy_sf(
-                              gvars[:crop].CCo, 
+                              gvars[:crop].CCo,
                               gvars[:crop].CGC,
                               gvars[:crop].CCx,
                               gvars[:crop].DaysToGermination,
@@ -181,7 +181,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
                               gvars[:crop].DaysToFlowering,
                               gvars[:crop].LengthFlowering,
                               gvars[:crop].DeterminancyLinked,
-                              gvars[:crop].DaysToFullCanopySF, 
+                              gvars[:crop].DaysToFullCanopySF,
                               gvars[:simulation].EffectStress.RedCGC,
                               gvars[:simulation].EffectStress.RedCCX,
                               gvars[:management].FertilityStress)
@@ -189,16 +189,16 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
         gvars[:simulation].EffectStress.RedCGC = RedCGC_temp
         gvars[:simulation].EffectStress.RedCCX = RedCCX_temp
         gvars[:crop].DaysToFullCanopySF = daystofullcanopy
-    end 
+    end
     setparameter!(gvars[:string_parameters], :man_file, man_file)
 
     # 6. Soil Profile
     if projectinput.Soil_Filename=="(External)"
         prof_file = projectinput.Soil_Filename
     elseif projectinput.Soil_Filename=="(None)"
-        if typeof(kwargs[:runtype]) == NormalFileRun 
+        if typeof(kwargs[:runtype]) == NormalFileRun
             prof_file = joinpath([test_dir, "SIMUL", "DEFAULT.SOL"])
-        elseif typeof(kwargs[:runtype]) == TomlFileRun 
+        elseif typeof(kwargs[:runtype]) == TomlFileRun
             prof_file = joinpath( test_toml_dir, "gvars.toml")
         elseif typeof(kwargs[:runtype]) == NoFileRun
             prof_file = joinpath( projectinput.ParentDir, "")
@@ -206,7 +206,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
     else
         # The load of profile is delayed to check if soil water profile need to be reset (see 8.)
         prof_file = joinpath([projectinput.ParentDir, projectinput.Soil_Directory, projectinput.Soil_Filename])
-    end 
+    end
     setparameter!(gvars[:string_parameters], :prof_file, prof_file)
 
 
@@ -216,7 +216,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
     else
         # Loading the groundwater is done after loading the soil profile (see 9.)
         groundwater_file = joinpath([projectinput.ParentDir, projectinput.GroundWater_Directory, projectinput.GroundWater_Filename])
-    end 
+    end
     setparameter!(gvars[:string_parameters], :groundwater_file, groundwater_file)
 
     # 8. Set simulation period
@@ -224,7 +224,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
     gvars[:simulation].ToDayNr = projectinput.Simulation_DayNrN
     if (gvars[:crop].Day1 != gvars[:simulation].FromDayNr) | (gvars[:crop].DayN != gvars[:simulation].ToDayNr)
         gvars[:simulation].LinkCropToSimPeriod = false
-    end 
+    end
 
     # 9. Initial conditions
     if projectinput.SWCIni_Filename=="KeepSWC"
@@ -241,20 +241,20 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
             gvars[:soil] = soil
             gvars[:soil_layers] = soil_layers
             gvars[:compartments] = compartments
-        end 
+        end
         gvars[:soil].RootMax = root_max_in_soil_profile(gvars[:crop].RootMax, gvars[:soil_layers])
-        complete_profile_description!(gvars[:soil_layers], gvars[:compartments], gvars[:simulation], gvars[:total_water_content]) 
+        complete_profile_description!(gvars[:soil_layers], gvars[:compartments], gvars[:simulation], gvars[:total_water_content])
 
         # Adjust size of compartments if required
         totdepth = 0
-        for i in eachindex(gvars[:compartments]) 
+        for i in eachindex(gvars[:compartments])
             totdepth = totdepth + gvars[:compartments][i].Thickness
-        end 
+        end
         if gvars[:simulation].MultipleRunWithKeepSWC
             # Project with a sequence of simulation runs and KeepSWC
-            if round(Int, gvars[:simulation].MultipleRunConstZrx*1000)>round(Int, totdepth*1000) 
+            if round(Int, gvars[:simulation].MultipleRunConstZrx*1000)>round(Int, totdepth*1000)
                 adjust_size_compartments!(gvars, gvars[:simulation].MultipleRunConstZrx)
-            end 
+            end
         else
             if round(Int, gvars[:crop].RootMax*1000)>round(Int, totdepth*1000)
                 if round(Int, gvars[:soil].RootMax*1000)==round(Int, gvars[:crop].RootMax*1000)
@@ -264,17 +264,17 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
                     # restrictive soil layer
                     if round(Int, gvars[:soil].RootMax*1000)>round(Int, totdepth*1000)
                         adjust_size_compartments!(gvars, gvars[:soil].RootMax)
-                    end 
-                end 
+                    end
+                end
             end
-        end 
+        end
 
         if projectinput.SWCIni_Filename=="(None)"
             swcini_file = projectinput.SWCIni_Filename
         else
             swcini_file = projectinput.ParentDir * projectinput.SWCIni_Directory * projectinput.SWCIni_Filename
             load_initial_conditions!(gvars, swcini_file)
-        end 
+        end
         setparameter!(gvars[:string_parameters], :swcini_file, swcini_file)
 
         if gvars[:simulation].IniSWC.AtDepths
@@ -288,15 +288,15 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
             for i in eachindex(gvars[:compartments])
                 gvars[:simulation].ThetaIni[i] = gvars[:compartments][i].Theta
                 gvars[:simulation].ECeIni[i] = ececomp(gvars[:compartments][i], gvars[:soil_layers], gvars[:simulparam])
-            end 
+            end
             # ADDED WHEN DESINGNING 4.0 BECAUSE BELIEVED TO HAVE FORGOTTEN -
             # CHECK LATER
             if gvars[:management].BundHeight>=0.01
                 gvars[:simulation].SurfaceStorageIni = gvars[:float_parameters][:surfacestorage]
                 gvars[:simulation].ECStorageIni = gvars[:float_parameters][:ecstorage]
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     # 10. load the groundwater file if it exists (only possible for Version 4.0
     # and higher)
@@ -310,7 +310,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
     calculate_adjusted_fc!(gvars[:compartments], gvars[:soil_layers], gvars[:integer_parameters][:ziaqua]/100)
     if gvars[:simulation].IniSWC.AtFC & (swcini_file != "KeepSWC")
         reset_swc_to_fc!(gvars[:simulation], gvars[:compartments], gvars[:soil_layers], gvars[:integer_parameters][:ziaqua])
-    end 
+    end
 
     # 11. Off-season conditions
     if projectinput.OffSeason_Filename=="(None)"
@@ -318,7 +318,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
     else
         offseason_file = joinpath([projectinput.ParentDir, projectinput.OffSeason_Directory, projectinput.OffSeason_Filename])
         load_offseason!(gvars, offseason_file)
-    end 
+    end
     setparameter!(gvars[:string_parameters], :offseason_file, offseason_file)
 
     # 12. Field data
@@ -330,7 +330,7 @@ function load_simulation_project!(outputs, gvars, projectinput::ProjectInputType
     setparameter!(gvars[:string_parameters], :observations_file, observations_file)
 
     return nothing
-end 
+end
 
 """
     read_temperature_file!(array_parameters::ParametersContainer{T}, temperature_file; kwargs...) where T
@@ -338,13 +338,13 @@ end
 tempprocessing.f90:ReadTemperatureFilefull:358
 """
 function read_temperature_file!(array_parameters::ParametersContainer{T}, temperature_file; kwargs...) where T
-    return _read_temperature_file!(kwargs[:runtype], array_parameters, temperature_file; kwargs...) 
+    return _read_temperature_file!(kwargs[:runtype], array_parameters, temperature_file; kwargs...)
 end
 
 function _read_temperature_file!(runtype::NormalFileRun, array_parameters::ParametersContainer{T}, temperature_file; kwargs...) where T
-    Tmin = Float64[] 
+    Tmin = Float64[]
     Tmax = Float64[]
-    
+
     open(temperature_file, "r") do file
         readline(file)
         readline(file)
@@ -357,7 +357,7 @@ function _read_temperature_file!(runtype::NormalFileRun, array_parameters::Param
 
         for line in eachline(file)
             splitedline = split(line)
-            
+
             tmin = parse(Float64,popfirst!(splitedline))
             tmax = parse(Float64,popfirst!(splitedline))
             push!(Tmin, tmin)
@@ -372,15 +372,15 @@ function _read_temperature_file!(runtype::NormalFileRun, array_parameters::Param
 end
 
 function _read_temperature_file!(runtype::TomlFileRun, array_parameters::ParametersContainer{T}, temperature_file; kwargs...) where T
-    Tmin = Float64[] 
+    Tmin = Float64[]
     Tmax = Float64[]
-    
+
     open(temperature_file, "r") do file
         readline(file)
 
         for line in eachline(file)
             splitedline = split(line)
-            
+
             tmin = parse(Float64,popfirst!(splitedline))
             tmax = parse(Float64,popfirst!(splitedline))
             push!(Tmin, tmin)
@@ -401,12 +401,12 @@ function _read_temperature_file!(runtype::NoFileRun, array_parameters::Parameter
 end
 
 function read_eto_file!(array_parameters::ParametersContainer{T}, eto_file; kwargs...) where T
-    return _read_eto_file!(kwargs[:runtype], array_parameters, eto_file; kwargs...) 
+    return _read_eto_file!(kwargs[:runtype], array_parameters, eto_file; kwargs...)
 end
 
 function _read_eto_file!(runtype::NormalFileRun, array_parameters::ParametersContainer{T}, eto_file; kwargs...) where T
-    ETo = Float64[] 
-    
+    ETo = Float64[]
+
     open(eto_file, "r") do file
         readline(file)
         readline(file)
@@ -428,8 +428,8 @@ function _read_eto_file!(runtype::NormalFileRun, array_parameters::ParametersCon
 end
 
 function _read_eto_file!(runtype::TomlFileRun, array_parameters::ParametersContainer{T}, eto_file; kwargs...) where T
-    ETo = Float64[] 
-    
+    ETo = Float64[]
+
     open(eto_file, "r") do file
         readline(file)
 
@@ -449,12 +449,12 @@ function _read_eto_file!(runtype::NoFileRun, array_parameters::ParametersContain
 end
 
 function read_rain_file!(array_parameters::ParametersContainer{T}, rain_file; kwargs...) where T
-    return _read_rain_file!(kwargs[:runtype], array_parameters, rain_file; kwargs...) 
+    return _read_rain_file!(kwargs[:runtype], array_parameters, rain_file; kwargs...)
 end
 
 function _read_rain_file!(runtype::NormalFileRun, array_parameters::ParametersContainer{T}, rain_file; kwargs...) where T
-    Rain = Float64[] 
-    
+    Rain = Float64[]
+
     open(rain_file, "r") do file
         readline(file)
         readline(file)
@@ -476,8 +476,8 @@ function _read_rain_file!(runtype::NormalFileRun, array_parameters::ParametersCo
 end
 
 function _read_rain_file!(runtype::TomlFileRun, array_parameters::ParametersContainer{T}, rain_file; kwargs...) where T
-    Rain = Float64[] 
-    
+    Rain = Float64[]
+
     open(rain_file, "r") do file
         readline(file)
 
@@ -518,9 +518,9 @@ function _load_clim!(runtype::NormalFileRun, record::RepClim, clim_file; kwargs.
             else
                 record.Datatype = :Monthly
             end
-            record.FromD = parse(Int,split(readline(file))[1]) 
-            record.FromM = parse(Int,split(readline(file))[1]) 
-            record.FromY = parse(Int,split(readline(file))[1]) 
+            record.FromD = parse(Int,split(readline(file))[1])
+            record.FromM = parse(Int,split(readline(file))[1])
+            record.FromY = parse(Int,split(readline(file))[1])
             record.NrObs = kwargs[:nrobs]
         end
         complete_climate_description!(record)
@@ -530,7 +530,7 @@ end
 
 function _load_clim!(runtype::T, record::RepClim, clim_file; kwargs...) where T<:TomlFileRun
     if isfile(clim_file)
-        load_gvars_from_toml!(record, clim_file; kwargs...) 
+        load_gvars_from_toml!(record, clim_file; kwargs...)
         record.NrObs = kwargs[:nrobs]
         complete_climate_description!(record)
     end
@@ -565,17 +565,17 @@ function complete_climate_description!(record::RepClim)
                 record.ToM = 1
                 record.ToY = record.ToY  + 1
             end
-        end 
+        end
         record.ToD = 10
-        if (deci == 2) 
+        if (deci == 2)
             record.ToD = 20
-        end 
-        if (deci == 3) 
+        end
+        if (deci == 3)
             record.ToD = DaysInMonth[record.ToM]
-            if (record.ToM == 2) & isleapyear(record.ToY) 
+            if (record.ToM == 2) & isleapyear(record.ToY)
                 record.ToD = record.ToD + 1
-            end 
-        end 
+            end
+        end
         record.ToDayNr =  determine_day_nr(record.ToD, record.ToM, record.ToY)
     elseif record.Datatype == :Monthly
         record.ToY = record.FromY
@@ -585,11 +585,11 @@ function complete_climate_description!(record::RepClim)
             record.ToM = record.ToM - 12
         end
         record.ToD = DaysInMonth[record.ToM]
-        if (record.ToM == 2) & isleapyear(record.ToY) 
+        if (record.ToM == 2) & isleapyear(record.ToY)
             record.ToD = record.ToD + 1
-        end 
+        end
         record.ToDayNr = determine_day_nr(record.ToD, record.ToM, record.ToY)
-    end 
+    end
     return nothing
 end
 
@@ -609,7 +609,7 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
     temperature_file = projectinput.Temperature_Filename
 
     # Part A - ETo and Rain files --> ClimFile
-    if ((eto_file == "(None)") & (rain_file == "(None)")) 
+    if ((eto_file == "(None)") & (rain_file == "(None)"))
         clim_file = "(None)"
         clim_record.Datatype =:Daily
         clim_record.FromString = "any date"
@@ -617,7 +617,7 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
         clim_record.FromY = 1901
     else
         clim_file = "EToRainTempFile"
-        if (eto_file == "(None)") 
+        if (eto_file == "(None)")
             clim_record.FromY = rain_record.FromY
             clim_record.FromDayNr = rain_record.FromDayNr
             clim_record.ToDayNr = rain_record.ToDayNr
@@ -626,7 +626,7 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
             if full_undefined_record(rain_record)
                 clim_record.NrObs = 365
             end
-        elseif (rain_file == "(None)") 
+        elseif (rain_file == "(None)")
             clim_record.FromY = eto_record.FromY
             clim_record.FromDayNr = eto_record.FromDayNr
             clim_record.ToDayNr = eto_record.ToDayNr
@@ -636,9 +636,9 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
                 clim_record.NrObs = 365
             end
         else
-            if full_undefined_record(eto_record) & full_undefined_record(rain_record) 
+            if full_undefined_record(eto_record) & full_undefined_record(rain_record)
                 clim_record.NrObs = 365
-            end 
+            end
 
             if (eto_record.FromY == 1901) & (rain_record.FromY != 1901)
                 eto_record.FromY = rain_record.FromY
@@ -652,9 +652,9 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
                     eto_record.ToY = rain_record.ToY
                 else
                     eto_record.ToY = eto_record.FromY
-                end 
+                end
                 eto_record.FromDayNr = determine_day_nr(eto_record.FromD, eto_record.FromM, eto_record.FromY)
-            end 
+            end
 
             if (eto_record.FromY != 1901) & (rain_record.FromY == 1901)
                 rain_record.FromY = eto_record.FromY
@@ -668,9 +668,9 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
                     rain_record.ToY = eto_record.ToY
                 else
                     rain_record.ToY = rain_record.FromY
-                end 
+                end
                 rain_record.FromDayNr = determine_day_nr(rain_record.FromD, rain_record.FromM, rain_record.FromY)
-            end 
+            end
             # ! bepaal characteristieken van ClimRecord
             clim_record.FromY = eto_record.FromY
             clim_record.FromDayNr = eto_record.FromDayNr
@@ -681,14 +681,14 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
             clim_record.ToDayNr = eto_record.ToDayNr
             if clim_record.ToDayNr > rain_record.ToDayNr
                 clim_record.ToDayNr = rain_record.ToDayNr
-            end 
+            end
             if clim_record.ToDayNr < clim_record.FromDayNr
                 clim_file = "(None)"
                 clim_record.NrObs = 0
                 clim_record.FromY = 1901
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     # Part B - ClimFile and Temperature files --> ClimFile
     if (temperature_file != "(None)") & (temperature_file != "(External)")
@@ -709,22 +709,22 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
                 clim_record.NrObs = 365
             else
                 clim_record.NrObs = temperature_record.ToDayNr - temperature_record.FromDayNr + 1
-            end 
-            
+            end
+
             if (clim_record.FromY == 1901) & (temperature_record != 1901)
                 clim_record.FromY = temperature_record.FromY
                 clim_record.FromDayNr = determine_day_nr(clim_record.FromD, clim_record.FromM, clim_record.FromY)
                 if (clim_record.FromDayNr < temperature_record.FromDayNr) & (temperature_record.FromY < temperature_record.ToY)
                     clim_record.FromY = temperature_record.FromY + 1
                     clim_record.FromDayNr = determine_day_nr(clim_record.FromD, clim_record.FromM, clim_record.FromY)
-                end 
+                end
                 if full_undefined_record(clim_record)
                     clim_record.ToY = temperature_record.ToY
                 else
                     clim_record.ToY = clim_record.FromY
                 end
                 clim_record.ToDayNr = determine_day_nr(clim_record.ToD, clim_record.ToM, clim_record.ToY)
-            end 
+            end
 
             if (clim_record.FromY != 1901) & (temperature_record == 1901)
                 temperature_record.FromY = clim_record.FromY
@@ -732,14 +732,14 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
                 if (temperature_record.FromDayNr < clim_record.FromDayNr) & (clim_record.FromY < clim_record.ToY)
                     temperature_record.FromY = clim_record.FromY + 1
                     temperature_record.FromDayNr = determine_day_nr(temperature_record.FromD, temperature_record.FromM, temperature_record.FromY)
-                end 
+                end
                 if full_undefined_record(temperature_record)
                     temperature_record.ToY = clim_record.ToY
                 else
                     temperature_record.ToY = temperature_record.FromY
                 end
                 temperature_record.ToDayNr = determine_day_nr(temperature_record.ToD, temperature_record.ToM, temperature_record.ToY)
-            end 
+            end
 
             # ! bepaal nieuwe characteristieken van ClimRecord
             if clim_record.FromDayNr < temperature_record.FromDayNr
@@ -754,8 +754,8 @@ function set_clim_data!(gvars, projectinput::ProjectInputType)
                 clim_record.NrObs = 0
                 clim_record.FromY = 1901
             end
-        end 
-    end 
+        end
+    end
 
     setparameter!(gvars[:string_parameters], :clim_file, clim_file)
     return nothing
@@ -800,8 +800,8 @@ function adjust_onset_search_period!(gvars)
         if onset.StopSearchDayNr > clim_record.ToDayNr
             onset.StopSearchDayNr = clim_record.ToDayNr
             onset.LengthSearchPeriod = onset.StopSearchDayNr - onset.StartSearchDayNr + 1
-        end 
-    end 
+        end
+    end
 
     return nothing
 end
@@ -828,7 +828,7 @@ function _load_crop!(runtype::NormalFileRun, crop::RepCrop, perennial_period::Re
             crop.subkind = :Vegetative
         elseif xx==2
             crop.subkind = :Grain
-        elseif xx==3 
+        elseif xx==3
             crop.subkind = :Tuber
         elseif xx==4
             crop.subkind = :Forage
@@ -909,7 +909,7 @@ function _load_crop!(runtype::NormalFileRun, crop::RepCrop, perennial_period::Re
             (crop.StressResponse.ShapeWP>24.9) & (crop.StressResponse.ShapeCDecline>24.9))
             crop.StressResponse.Calibrated = false
         else
-            crop.StressResponse.Calibrated = true 
+            crop.StressResponse.Calibrated = true
         end
 
         # temperature stress
@@ -1071,7 +1071,7 @@ function _load_crop!(runtype::NormalFileRun, crop::RepCrop, perennial_period::Re
             # Transfer of assimilates from
             # above ground parts to root
             # system is NOT considered
-            crop.Assimilates.On = false 
+            crop.Assimilates.On = false
         end
         # Number of days at end of season
         # during which assimilates are
@@ -1106,7 +1106,7 @@ function _load_crop!(runtype::NormalFileRun, crop::RepCrop, perennial_period::Re
                     perennial_period.GenerateOnset = false
                 end
             end
-            
+
             perennial_period.OnsetFirstDay = parse(Int, split(readline(file))[1])
             perennial_period.OnsetFirstMonth = parse(Int, split(readline(file))[1])
             perennial_period.OnsetLengthSearchPeriod = parse(Int, split(readline(file))[1])
@@ -1120,7 +1120,7 @@ function _load_crop!(runtype::NormalFileRun, crop::RepCrop, perennial_period::Re
             if perennial_period.OnsetOccurrence > 3
                 perennial_period.OnsetOccurrence = 3
             end
-            
+
             # 3. END of growing period
             xx = parse(Int, split(readline(file))[1])
             if xx==0
@@ -1164,7 +1164,7 @@ function _load_crop!(runtype::T, crop::RepCrop, perennial_period::RepPerennialPe
     load_gvars_from_toml!(crop, crop_file)
     load_gvars_from_toml!(perennial_period, crop_file)
     return nothing
-end 
+end
 
 function _load_crop!(runtype::T, crop::RepCrop, perennial_period::RepPerennialPeriod, crop_file; kwargs...) where T<:NoFileRun
     set_crop!(crop, kwargs[:crop_type]; aux = haskey(kwargs, :crop) ? kwargs[:crop] : nothing)
@@ -1182,30 +1182,30 @@ function derive_smax_top_bottom(crop::RepCrop)
     sxbotq = crop.SmaxBotQuarter
     v1 = sxtopq
     v2 = sxbotq
-    if (abs(v1 - v2) < 1e-12) 
+    if (abs(v1 - v2) < 1e-12)
         sxtop = v1
         sxbot = v2
     else
-        if (sxtopq < sxbotq) 
+        if (sxtopq < sxbotq)
             v1 = sxbotq
             v2 = sxtopq
-        end 
+        end
         x = 3 * v2/(v1-v2)
-        if (x < 0.5) 
+        if (x < 0.5)
             v11 = (4/3.5) * v1
             v22 = 0
         else
             v11 = (x + 3.5) * v1/(x+3)
             v22 = (x - 0.5) * v2/x
-        end 
-        if (sxtopq > sxbotq) 
+        end
+        if (sxtopq > sxbotq)
             sxtop = v11
             sxbot = v22
         else
             sxtop = v22
             sxbot = v11
-        end 
-    end 
+        end
+    end
 
     return sxtop, sxbot
 end
@@ -1229,41 +1229,41 @@ function adjust_year_perennials!(crop::RepCrop, theyearseason)
     theplantingdens  = crop.PlantingDens
     thesizeplant = crop.SizePlant
 
-    if (theyearseason == 1) 
+    if (theyearseason == 1)
         if (sownyear1 == true)  # planting
             typeofplanting = :Seed
         else
             typeofplanting = :Transplant
-        end 
+        end
         zmin = zminyear1  # rooting depth
     else
         typeofplanting = :Regrowth # planting
         zmin = zmax  # rooting depth
         # plant size by regrowth
-        if (round(Int, 100*thesizeplant) < round(100*thesizeseedling)) 
+        if (round(Int, 100*thesizeplant) < round(100*thesizeseedling))
             thesizeplant = 10 * thesizeseedling
-        end 
-        if (round(Int, 100*thesizeplant) > 
-            round(Int, (100*theccx*10000)/(theplantingdens/10000))) 
+        end
+        if (round(Int, 100*thesizeplant) >
+            round(Int, (100*theccx*10000)/(theplantingdens/10000)))
             # adjust size plant to maximum possible
             thesizeplant = (theccx*10000)/(theplantingdens/10000p)
-        end 
-    end 
+        end
+    end
     theccini = (theplantingdens/10000) * (thesizeplant/10000)
-    thedaystoccini = time_to_cc_ini(typeofplanting, theplantingdens, 
+    thedaystoccini = time_to_cc_ini(typeofplanting, theplantingdens,
                        thesizeseedling, thesizeplant, theccx, thecgc)
-    if (thecyclemode == :GDDays) 
-        thegddaystoccini = time_to_cc_ini(typeofplanting, theplantingdens, 
+    if (thecyclemode == :GDDays)
+        thegddaystoccini = time_to_cc_ini(typeofplanting, theplantingdens,
                        thesizeseedling, thesizeplant, theccx, thegddcgc)
     else
         thegddaystoccini = undef_int
-    end 
+    end
 
     crop.Planting = typeofplanting
     crop.RootMin = zmin
     crop.SizePlant = thesizeplant
     crop.CCini = theccini
-    crop.DaysToCCini = thedaystoccini  
+    crop.DaysToCCini = thedaystoccini
     crop.GDDaysToCCini = thegddaystoccini
 
     return nothing
@@ -1289,39 +1289,39 @@ function adjust_crop_file_parameters!(gvars)
     # Adjust some crop parameters (CROP.*) as specified by the generated length
     # season (LseasonDays)
     # time to maturity
-    if (themodecycle == :GDDays) 
-        tmin_tmp = simulparam.Tmin 
-        tmax_tmp = simulparam.Tmax 
-        gdd1234 = growing_degree_days(lseasondays, thecropday1, thetbase, thetupper, gvars, tmin_tmp, tmax_tmp) 
+    if (themodecycle == :GDDays)
+        tmin_tmp = simulparam.Tmin
+        tmax_tmp = simulparam.Tmax
+        gdd1234 = growing_degree_days(lseasondays, thecropday1, thetbase, thetupper, gvars, tmin_tmp, tmax_tmp)
 
     else
         gdd1234 = undef_int
-    end 
+    end
 
     # time to senescence  (reference is given in thecropfileset
-    if (themodecycle == :GDDays) 
+    if (themodecycle == :GDDays)
         gdd123 = gdd1234 - crop_file_set.GDDaysFromSenescenceToEnd
-        if (gdd123 >= gdd1234) 
+        if (gdd123 >= gdd1234)
             gdd123 = gdd1234
             l123 = lseasondays
         else
-            tmin_tmp = simulparam.Tmin 
-            tmax_tmp = simulparam.Tmax 
+            tmin_tmp = simulparam.Tmin
+            tmax_tmp = simulparam.Tmax
             l123 = sum_calendar_days(gdd123, thecropday1, thetbase, thetupper, tmin_tmp, tmax_tmp, gvars)
-        end 
+        end
     else
         l123 = lseasondays - crop_file_set.DaysFromSenescenceToEnd
         if (l123 >= lseasondays)
             l123 = lseasondays
         end
         gdd123 = undef_int
-    end 
+    end
     crop.DaysToSenescence = l123
     crop.GDDaysToSenescence = gdd123
     crop.GDDaysToHarvest = gdd1234
 
     return nothing
-end 
+end
 
 """
     gdd1234 = growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, tdaymin, tdaymax)
@@ -1343,7 +1343,7 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
     tdaymax_local = tdaymax
     gddays = 0
 
-    if (valperiod > 0) 
+    if (valperiod > 0)
         if (temperature_file=="(None)") | (temperature_file=="(External)")
             # OJO this includes temperature_file = "None" and "External" because we never set TminRun
             # given average Tmin and Tmax
@@ -1357,7 +1357,7 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
                 daynri = set_daynr_to_yundef(daynri)
             else
                 adjustdaynri = false
-            end 
+            end
 
             if temperature_file_exists & (temperature_record.ToDayNr>daynri) & (temperature_record.FromDayNr<=daynri)
                 remainingdays = valperiod
@@ -1374,9 +1374,9 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
 
                     while ((remainingdays > 0) & ((daynri < temperature_record.ToDayNr) | adjustdaynri))
                         i = i + 1
-                        if (i == length(Tmin)) 
+                        if (i == length(Tmin))
                             i = 1
-                        end 
+                        end
                         tdaymin_local = Tmin[i]
                         tdaymax_local = Tmax[i]
 
@@ -1385,17 +1385,17 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
                         gddays = gddays + daygdd
                         remainingdays = remainingdays - 1
                         daynri = daynri + 1
-                    end 
+                    end
 
-                    if (remainingdays > 0) 
+                    if (remainingdays > 0)
                         gddays = undef_int
-                    end 
+                    end
                 elseif temperature_record.Datatype == :Decadely
                     get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                     i = 1
                     while (tmin_dataset[i].DayNr != daynri)
                         i = i+1
-                    end 
+                    end
                     tdaymin_local = tmin_dataset[i].Param
                     tdaymax_local = tmax_dataset[i].Param
 
@@ -1419,9 +1419,9 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
                         remainingdays = remainingdays - 1
                         daynri = daynri + 1
                     end
-                    if (remainingdays > 0) 
+                    if (remainingdays > 0)
                         gddays = undef_int
-                    end 
+                    end
                 elseif temperature_record.Datatype == :Monthly
                     get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                     i = 1
@@ -1435,7 +1435,7 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
                     remainingdays = remainingdays - 1
                     daynri = daynri + 1
                     while((remainingdays > 0) & ((daynri < temperature_record.ToDayNr) | adjustdaynri))
-                        if (daynri > tmin_dataset[31].DayNr) 
+                        if (daynri > tmin_dataset[31].DayNr)
                             get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                         end
                         i = 1
@@ -1448,11 +1448,11 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
                         gddays = gddays + daygdd
                         remainingdays = remainingdays - 1
                         daynri = daynri + 1
-                    end 
-                    if (remainingdays > 0) 
+                    end
+                    if (remainingdays > 0)
                         gddays = undef_int
-                    end 
-                end 
+                    end
+                end
             end
         end
     else
@@ -1460,7 +1460,7 @@ function growing_degree_days(valperiod, firstdayperiod, tbase, tupper, gvars, td
     end
     gdd1234 = round(Int, gddays)
     return gdd1234
-end 
+end
 
 """
     dgrd = degrees_day(tbase, tupper, tdaymin, tdaymax, gddselectedmethod)
@@ -1471,50 +1471,50 @@ function degrees_day(tbase, tupper, tdaymin, tdaymax, gddselectedmethod)
     if gddselectedmethod==1
         # method 1. - no adjustemnt of tmax, tmin before calculation of taverage
         tavg = (tdaymax+tdaymin)/2
-        if (tavg > tupper) 
+        if (tavg > tupper)
             tavg = tupper
-        end 
-        if (tavg < tbase) 
+        end
+        if (tavg < tbase)
             tavg = tbase
         end
     elseif gddselectedmethod==2
         # method 2. -  adjustment for tbase before calculation of taverage
         tstarmax = tdaymax
-        if (tdaymax < tbase) 
+        if (tdaymax < tbase)
             tstarmax = tbase
-        end 
-        if (tdaymax > tupper) 
+        end
+        if (tdaymax > tupper)
             tstarmax = tupper
-        end 
+        end
         tstarmin = tdaymin
-        if (tdaymin < tbase) 
+        if (tdaymin < tbase)
             tstarmin = tbase
-        end 
-        if (tdaymin > tupper) 
+        end
+        if (tdaymin > tupper)
             tstarmin = tupper
-        end 
+        end
         tavg = (tstarmax+tstarmin)/2
     else
         # method 3.
         tstarmax = tdaymax
-        if (tdaymax < tbase) 
+        if (tdaymax < tbase)
              tstarmax = tbase
-        end 
-        if (tdaymax > tupper) 
+        end
+        if (tdaymax > tupper)
             tstarmax = tupper
-        end 
+        end
         tstarmin = tdaymin
-        if (tdaymin > tupper) 
+        if (tdaymin > tupper)
             tstarmin = tupper
-        end 
+        end
         tavg = (tstarmax+tstarmin)/2
-        if (tavg < tbase) 
+        if (tavg < tbase)
             tavg = tbase
-        end 
-    end 
+        end
+    end
     dgrd =  tavg - tbase
     return  dgrd
-end 
+end
 
 """
     daynri = set_daynr_to_yundef(daynri)
@@ -1535,15 +1535,15 @@ tempprocessing.f90:GetDecadeTemperatureDataSet:413
 """
 function get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, temperature_array, temperature_record::RepClim)
     dayi, monthi, yeari = determine_date(daynri)
-    if (dayi > 20) 
+    if (dayi > 20)
         deci = 3
         dayi = 21
         dayn = DaysInMonth[monthi]
-        if ((monthi == 2) & isleapyear(yeari)) 
+        if ((monthi == 2) & isleapyear(yeari))
             dayn = dayn + 1
-        end 
+        end
         ni = dayn - dayi + 1
-    elseif (dayi > 10) 
+    elseif (dayi > 10)
         deci = 2
         dayi = 11
         dayn = 20
@@ -1553,44 +1553,44 @@ function get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, tem
         dayi = 1
         dayn = 10
         ni = 10
-    end 
+    end
     c1min, c1max, c2min, c2max, c3min, c3max = get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_array, temperature_record)
     dnr = determine_day_nr(dayi, monthi, yeari)
 
     ulmin, llmin, midmin = get_parameters(c1min, c2min, c3min)
     for nri in 1:ni
         tmin_dataset[nri].DayNr = dnr+nri-1
-        if (nri <= (ni/2+0.01)) 
+        if (nri <= (ni/2+0.01))
             tmin_dataset[nri].Param = (2*ulmin + (midmin-ulmin)*(2*nri-1)/(ni/2))/2
         else
-            if ((ni == 11) | (ni == 9)) & (nri < (ni+1.01)/2) 
+            if ((ni == 11) | (ni == 9)) & (nri < (ni+1.01)/2)
                 tmin_dataset[nri].Param = midmin
             else
                 tmin_dataset[nri].Param = (2*midmin + (llmin-midmin)*(2*nri-(ni+1))/(ni/2))/2
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     ulmax, llmax, midmax = get_parameters(c1max, c2max, c3max)
     for nri in 1:ni
         tmax_dataset[nri].DayNr = dnr+nri-1
-        if (nri <= (ni/2+0.01)) 
+        if (nri <= (ni/2+0.01))
             tmax_dataset[nri].Param = (2*ulmax + (midmax-ulmax)*(2*nri-1)/(ni/2))/2
         else
-            if ((ni == 11) | (ni == 9)) & (nri < (ni+1.01)/2) 
+            if ((ni == 11) | (ni == 9)) & (nri < (ni+1.01)/2)
                 tmax_dataset[nri].Param = midmax
             else
                 tmax_dataset[nri].Param = (2*midmax + (llmax-midmax)*(2*nri-(ni+1))/(ni/2))/2
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     for nri in (ni+1):31
         tmin_dataset[nri].DayNr = dnr+ni-1
         tmin_dataset[nri].Param = 0
         tmax_dataset[nri].DayNr = dnr+ni-1
         tmax_dataset[nri].Param = 0
-    end 
+    end
 
     return nothing
 end
@@ -1606,7 +1606,7 @@ function get_parameters(c1, c2, c3)
     mid = 2*c2 - (ul+ll)/2
     # --previous decade-->/ul/....... mid ......../ll/<--next decade--
     return ul, ll, mid
-end 
+end
 
 """
     c1min, c1max, c2min, c2max, c3min, c3max = get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_array, temperature_record::RepClim)
@@ -1629,7 +1629,7 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
         yfile = temperature_record.FromY
     end
     ok3 = false
-    
+
     cont = 1
     if temperature_record.NrObs<=2
         c1min = temperature_array[1][cont]
@@ -1648,7 +1648,7 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
             c3min = temperature_array[1][cont]
             c3max = temperature_array[2][cont]
             cont += 1
-            if (deci == decfile) 
+            if (deci == decfile)
                 c2min = c3min
                 c2max = c3max
                 c3min = c2min+(c2min-c1min)/4
@@ -1658,7 +1658,7 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
                 c2max = c1max
                 c1min = c2min + (c2min-c3min)/4
                 c1max = c2max + (c2max-c3max)/4
-            end 
+            end
         end
         ok3 = true
     end
@@ -1675,13 +1675,13 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
         c1min = c2min + (c2min-c3min)/4
         c1max = c2max + (c2max-c3max)/4
         ok3 = true
-    end 
+    end
 
     if (!ok3) & (dayn==temperature_record.ToD) & (monthi==temperature_record.ToM)
         if (temperature_record.FromY==1901) | (yeari==temperature_record.ToY)
             for Nri in 1:(temperature_record.NrObs-2)
                 cont += 1
-            end 
+            end
             c1min = temperature_array[1][cont]
             c1max = temperature_array[2][cont]
             cont += 1
@@ -1691,17 +1691,17 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
             c3min = c2min+(c2min-c1min)/4
             c3max = c2max+(c2max-c1max)/4
             ok3 = true
-        end 
-    end 
+        end
+    end
 
-    if !ok3 
+    if !ok3
         obsi = 1
         while !ok3
-            if (deci==decfile) & (monthi==mfile) & (yeari == yfile) 
+            if (deci==decfile) & (monthi==mfile) & (yeari == yfile)
                 ok3 = true
             else
                 decfile = decfile + 1
-                if decfile>3 
+                if decfile>3
                     decfile, mfile, yfile = adjust_decade_month_and_year(decfile, mfile, yfile)
                 end
                 obsi = obsi + 1
@@ -1716,7 +1716,7 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
         end
         for nri in 1:(obsi-2)
             cont += 1
-        end 
+        end
         c1min = temperature_array[1][cont]
         c1max = temperature_array[2][cont]
         cont += 1
@@ -1726,12 +1726,12 @@ function get_set_of_three_temperature(dayn, deci, monthi, yeari, temperature_arr
         c3min = temperature_array[1][cont]
         c3max = temperature_array[2][cont]
         cont += 1
-    end 
+    end
 
     return c1min, c1max, c2min, c2max, c3min, c3max
-end 
+end
 
-""" 
+"""
     decfile, mfile, yfile = adjust_decade_month_and_year(decfile, mfile, yfile)
 
 tempprocessing.f90:AdjustDecadeMONTHandYEAR:344
@@ -1739,10 +1739,10 @@ tempprocessing.f90:AdjustDecadeMONTHandYEAR:344
 function adjust_decade_month_and_year(decfile, mfile, yfile)
     decfile = 1
     mfile = mfile + 1
-    if (mfile > 12) 
+    if (mfile > 12)
         mfile = 1
         yfile = yfile + 1
-    end 
+    end
     return decfile, mfile, yfile
 end
 
@@ -1770,9 +1770,9 @@ function get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, te
     dayi = 1
     dnr = determine_day_nr(dayi, monthi, yeari)
     dayn = DaysInMonth[monthi]
-    if ((monthi == 2) & isleapyear(yeari)) 
+    if ((monthi == 2) & isleapyear(yeari))
         dayn = dayn + 1
-    end 
+    end
 
     aover3min, bover2min, cmin = get_interpolation_parameters(c1min, c2min, c3min)
     aover3max, bover2max, cmax = get_interpolation_parameters(c1max, c2max, c3max)
@@ -1783,15 +1783,15 @@ function get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, te
         tmin_dataset[dayi].Param = aover3min*(t2*t2*t2-t1*t1*t1) + bover2min*(t2*t2-t1*t1) + cmin*(t2-t1)
         tmax_dataset[dayi].Param = aover3max*(t2*t2*t2-t1*t1*t1) + bover2max*(t2*t2-t1*t1) + cmax*(t2-t1)
         t1 = t2
-    end 
+    end
     for dayi in (dayn+1):31
         tmin_dataset[dayi].DayNr = dnr+dayn-1 #OJO maybe is dayi
         tmax_dataset[dayi].DayNr = dnr+dayn-1 #OJO maybe is dayi
         tmin_dataset[dayi].Param = 0
         tmax_dataset[dayi].Param = 0
-    end 
+    end
     return nothing
-end 
+end
 
 """
     c1min, c2min, c3min, c1max, c2max, c3max, x1, x2, x3, t1 = get_set_of_three_months_temperature(monthi, yeari, temperature_array, temperature_record::RepClim)
@@ -1829,12 +1829,12 @@ function get_set_of_three_months_temperature(monthi, yeari, temperature_array, t
         elseif temperature_record.NrObs==1
             t1 = x1
             mfile = mfile + 1
-            if mfile>12 
+            if mfile>12
                 mfile, yfile = adjust_month_and_year(mfile, yfile)
-            end 
+            end
             c3min, c3max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
             cont += 1
-            if monthi==mfile 
+            if monthi==mfile
                 c2min = c3min
                 c2max = c3max
                 x2 = x1 + n3
@@ -1844,34 +1844,34 @@ function get_set_of_three_months_temperature(monthi, yeari, temperature_array, t
                 c2max = c1max
                 x2 = x1 + n1
                 x3 = x2 + n3
-            end 
+            end
         elseif temperature_record.NrObs==2
-            if monthi==mfile 
+            if monthi==mfile
                 t1 = 0
-            end 
+            end
             mfile = mfile + 1
-            if mfile>12 
+            if mfile>12
                 mfile, yfile = adjust_month_and_year(mfile, yfile)
             end
             c2min, c2max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
             cont += 1
             x2 = x1 + n2
-            if monthi==mfile 
+            if monthi==mfile
                 t1 = x1
-            end 
+            end
             mfile = mfile + 1
-            if mfile>12 
+            if mfile>12
                 mfile, yfile = adjust_month_and_year(mfile, yfile)
             end
             c3min, c3max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
             cont += 1
             x3 = x2 + n3
-            if monthi==mfile 
+            if monthi==mfile
                 t1 = x2
-            end 
+            end
         end
         ok3 = true
-    end 
+    end
 
     # 3. If first observation
     if (!ok3) & (monthi==mfile) & (yeari==yfile)
@@ -1880,21 +1880,21 @@ function get_set_of_three_months_temperature(monthi, yeari, temperature_array, t
         cont += 1
         x1 = n1
         mfile = mfile + 1
-        if mfile>12 
+        if mfile>12
             mfile, yfile = adjust_month_and_year(mfile, yfile)
-        end 
+        end
         c2min, c2max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
         cont += 1
         x2 = x1 + n2
         mfile = mfile + 1
-        if mfile>12 
+        if mfile>12
             mfile, yfile = adjust_month_and_year(mfile, yfile)
-        end 
+        end
         c3min, c3max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
         cont += 1
         x3 = x2 + n3
         ok3 = true
-    end 
+    end
 
     # 4. If last observation
     if (!ok3) & (monthi==temperature_record.ToM)
@@ -1902,51 +1902,51 @@ function get_set_of_three_months_temperature(monthi, yeari, temperature_array, t
             for nri in 1:(temperature_record.NrObs-3)
                 cont += 1
                 mfile = mfile + 1
-                if mfile>12 
+                if mfile>12
                     mfile, yfile = adjust_month_and_year(mfile, yfile)
-                end 
-            end 
+                end
+            end
             c1min, c1max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
             cont += 1
             x1 = n1
             mfile = mfile + 1
-            if mfile>12 
+            if mfile>12
                 mfile, yfile = adjust_month_and_year(mfile, yfile)
-            end 
+            end
             c2min, c2max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
             cont += 1
             x2 = x1 + n2
             t1 = x2
             mfile = mfile + 1
-            if mfile>12 
+            if mfile>12
                 mfile, yfile = adjust_month_and_year(mfile, yfile)
-            end 
+            end
             c3min, c3max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
             cont += 1
             x3 = x2 + n3
             ok3 = true
-        end 
-    end 
+        end
+    end
 
     # 5. IF not previous cases
     if !ok3
         obsi = 1
         while !ok3
-            if ((monthi==mfile) & (yeari==yfile)) 
+            if ((monthi==mfile) & (yeari==yfile))
                ok3 = true
             else
                mfile = mfile + 1
-               if mfile>12 
+               if mfile>12
                    mfile, yfile = adjust_month_and_year(mfile, yfile)
-               end 
+               end
               obsi = obsi + 1
-            end 
-        end 
-        mfile = temperature_record.FromM 
+            end
+        end
+        mfile = temperature_record.FromM
         for nri in 1:(obsi-2)
             cont += 1
             mfile = mfile + 1
-            if (mfile > 12) 
+            if (mfile > 12)
                 mfile, yfile = adjust_month_and_year(mfile, yfile)
             end
         end
@@ -1955,23 +1955,23 @@ function get_set_of_three_months_temperature(monthi, yeari, temperature_array, t
         x1 = n1
         t1 = x1
         mfile = mfile + 1
-        if mfile>12 
+        if mfile>12
             mfile, yfile = adjust_month_and_year(mfile, yfile)
-        end 
+        end
         c2min, c2max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
         cont += 1
         x2 = x1 + n2
         mfile = mfile + 1
-        if mfile>12 
+        if mfile>12
             mfile, yfile = adjust_month_and_year(mfile, yfile)
         end
         c3min, c3max = adjust_month(temperature_array[1][cont], temperature_array[2][cont])
         cont += 1
         x3 = x2 + n3
-    end 
+    end
 
     return c1min, c2min, c3min, c1max, c2max, c3max, x1, x2, x3, t1
-end 
+end
 
 """
     cimin, cimax = adjust_month(tlow, thigh)
@@ -2020,7 +2020,7 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
     tdaymax_loc = tdaymax
 
     nrcdays = 0
-    if valgddays>0 
+    if valgddays>0
         if (temperature_file=="(None)") | (temperature_file=="(External)")
             # OJO this includes temperature_file = "None" and "External" because we never set TminRun
             # given average Tmin and Tmax
@@ -2029,7 +2029,7 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
                 nrcdays = undef_int
             else
                 nrcdays = round(Int, valgddays/daygdd)
-            end 
+            end
         else
             daynri = firstdaycrop
             if full_undefined_record(temperature_record)
@@ -2037,7 +2037,7 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
                 daynri = set_daynr_to_yundef(daynri)
             else
                 adjustdaynri = false
-            end 
+            end
 
             if temperature_file_exists & (temperature_record.ToDayNr>daynri) & (temperature_record.FromDayNr<=daynri)
                 remaininggddays = valgddays
@@ -2054,9 +2054,9 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
 
                     while ((remaininggddays > 0) & ((daynri < temperature_record.ToDayNr) | adjustdaynri))
                         i = i + 1
-                        if i==length(Tmin) 
+                        if i==length(Tmin)
                             i = 1
-                        end 
+                        end
                         tdaymin_loc = Tmin[i]
                         tdaymax_loc = Tmax[i]
 
@@ -2064,17 +2064,17 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
                         nrcdays = nrcdays + 1
                         remaininggddays = remaininggddays - daygdd
                         daynri = daynri + 1
-                    end 
+                    end
 
-                    if remaininggddays>0 
+                    if remaininggddays>0
                         nrcdays = undef_int
-                    end 
+                    end
                 elseif temperature_record.Datatype==:Decadely
                     get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                     i = 1
                     while tmin_dataset[i].DayNr != daynri
                         i = i+1
-                    end 
+                    end
                     tdaymin_loc = tmin_dataset[i].Param
                     tdaymax_loc = tmax_dataset[i].Param
                     daygdd = degrees_day(tbase, tupper, tdaymin_loc, tdaymax_loc, simulparam.GDDMethod)
@@ -2082,29 +2082,29 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
                     remaininggddays = remaininggddays - daygdd
                     daynri = daynri + 1
                     while (remaininggddays>0) & ((daynri<temperature_record.ToDayNr) | (adjustdaynri))
-                        if daynri>tmin_dataset[31].DayNr 
+                        if daynri>tmin_dataset[31].DayNr
                             get_decade_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                         end
                         i = 1
                         while tmin_dataset[i].DayNr != daynri
                             i = i+1
-                        end 
+                        end
                         tdaymin_loc = tmin_dataset[i].Param
                         tdaymax_loc = tmax_dataset[i].Param
                         daygdd = degrees_day(tbase, tupper, tdaymin_loc, tdaymax_loc, simulparam.GDDMethod)
                         nrcdays = nrcdays + 1
                         remaininggddays = remaininggddays - daygdd
                         daynri = daynri + 1
-                    end 
-                    if remaininggddays>0 
+                    end
+                    if remaininggddays>0
                         nrcdays = undef_int
-                    end 
+                    end
                 elseif  temperature_record.Datatype==:Monthly
                     get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                     i = 1
                     while tmin_dataset[i].DayNr != daynri
                         i = i+1
-                    end 
+                    end
                     tdaymin_loc = tmin_dataset[i].Param
                     tdaymax_loc = tmax_dataset[i].Param
                     daygdd = degrees_day(tbase, tupper, tdaymin_loc, tdaymax_loc, simulparam.GDDMethod)
@@ -2112,31 +2112,31 @@ function sum_calendar_days(valgddays, firstdaycrop, tbase, tupper, tdaymin, tday
                     remaininggddays = remaininggddays - daygdd
                     daynri = daynri + 1
                     while (remaininggddays>0) & ((daynri<temperature_record.ToDayNr) | adjustdaynri)
-                        if daynri>tmin_dataset[31].DayNr 
+                        if daynri>tmin_dataset[31].DayNr
                             get_monthly_temperature_dataset!(tmin_dataset, tmax_dataset, daynri, (Tmin, Tmax), temperature_record)
                         end
                         i = 1
                         while tmin_dataset[i].DayNr != daynri
                             i = i+1
-                        end 
+                        end
                         tdaymin_loc = tmin_dataset[i].Param
                         tdaymax_loc = tmax_dataset[i].Param
                         daygdd = degrees_day(tbase, tupper, tdaymin_loc, tdaymax_loc, simulparam.GDDMethod)
                         nrcdays = nrcdays + 1
                         remaininggddays = remaininggddays - daygdd
                         daynri = daynri + 1
-                    end 
-                    if remaininggddays>0 
+                    end
+                    if remaininggddays>0
                         nrcdays = undef_int
-                    end 
-                end 
+                    end
+                end
             else
                 nrcdays = undef_int
             end
         end
     end
     return nrcdays
-end 
+end
 
 """
     adjust_calendar_crop!(gvars)
@@ -2150,13 +2150,13 @@ function adjust_calendar_crop!(gvars)
     if crop.ModeCycle==:GDDays
         crop.GDDaysToFullCanopy = crop.GDDaysToGermination +
                 round(Int, log((0.25*crop.CCx^2/crop.CCo)/(crop.CCx-0.98*crop.CCx))/crop.GDDCGC)
-        if crop.GDDaysToFullCanopy>crop.GDDaysToHarvest 
+        if crop.GDDaysToFullCanopy>crop.GDDaysToHarvest
             crop.GDDaysToFullCanopy = crop.GDDaysToHarvest
-        end 
+        end
         adjust_calendar_days!(gvars, cgcisgiven)
-    end 
+    end
     return nothing
-end 
+end
 
 
 """
@@ -2208,74 +2208,74 @@ function adjust_calendar_days!(gvars, iscgcgiven)
     tmp_notempfiletmax = notempfiletmax
 
     succes = true
-    if thedaystoccini==0 
+    if thedaystoccini==0
         # planting/sowing
         d0 = sum_calendar_days(gddl0, plantdaynr, tbase, tupper, notempfiletmin, notempfiletmax, gvars)
         d12 = sum_calendar_days(gddl12, plantdaynr, tbase, tupper, notempfiletmin, notempfiletmax, gvars)
     else
         # regrowth
-        if thedaystoccini>0 
+        if thedaystoccini>0
            # ccini < ccx
            extragddays = gddl12 - gddl0 - thegddaystoccini
            extradays = sum_calendar_days(extragddays, plantdaynr, tbase, tupper, notempfiletmin, notempfiletmax, gvars)
            d12 = d0 + thedaystoccini + extradays
-        end 
-    end 
+        end
+    end
 
-    if infocroptype != :Forage 
+    if infocroptype != :Forage
         d123 = sum_calendar_days(gddl123, plantdaynr, tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
         dharvest = sum_calendar_days(gddharvest, plantdaynr, tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
-    end 
+    end
 
     dlzmax = sum_calendar_days(gddlzmax, plantdaynr, tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
     if (infocroptype==:Grain) | (infocroptype==:Tuber)
         dflor = sum_calendar_days(gddflor, plantdaynr, tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
-        if dflor!=undef_int 
-            if infocroptype==:Grain 
+        if dflor!=undef_int
+            if infocroptype==:Grain
                 lengthflor = sum_calendar_days(gddlengthflor, (plantdaynr+dflor), tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
             else
                 lengthflor = 0
-            end 
+            end
             lhimax = sum_calendar_days(gddhimax, (plantdaynr+dflor), tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
-            if (lengthflor==undef_int) | (lhimax==undef_int) 
+            if (lengthflor==undef_int) | (lhimax==undef_int)
                 succes = false
-            end 
+            end
         else
             lengthflor = undef_int
             lhimax = undef_int
             succes = false
-        end 
+        end
     elseif (infocroptype==:Vegetative) | (infocroptype==:Forage)
         lhimax = sum_calendar_days(gddhimax, plantdaynr, tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
-    end 
-    if (d0==undef_int) | (d12 == undef_int) | (d123==undef_int) | (dharvest==undef_int) | (dlzmax==undef_int) 
+    end
+    if (d0==undef_int) | (d12 == undef_int) | (d123==undef_int) | (dharvest==undef_int) | (dlzmax==undef_int)
         succes = false
-    end 
+    end
 
-    if succes 
+    if succes
         cgc = gddl12/d12 * gddcgc
         cdc = gddcdc_to_cdc(plantdaynr, d123, gddl123, gddharvest, ccx, gddcdc, tbase, tupper, tmp_notempfiletmin, tmp_notempfiletmax, gvars)
         d123, stlength, d12, cgc = determine_length_growth_stages(cco, ccx, cdc, d0, dharvest, iscgcgiven, thedaystoccini, theplanting, d123, stlength, d12, cgc)
-        if (infocroptype==:Grain) | (infocroptype==:Tuber) 
+        if (infocroptype==:Grain) | (infocroptype==:Tuber)
             dhidt = hindex/lhimax
-        end 
-        if (infocroptype==:Vegetative) | (infocroptype==:Forage) 
-            if (lhimax > 0) 
-                if (lhimax > dharvest) 
+        end
+        if (infocroptype==:Vegetative) | (infocroptype==:Forage)
+            if (lhimax > 0)
+                if (lhimax > dharvest)
                     dhidt = hindex/dharvest
                 else
                     dhidt = hindex/lhimax
-                end 
-                if (dhidt > 100) 
+                end
+                if (dhidt > 100)
                     dhidt = 100 # 100 is maximum tempdhidt (see setdhidt)
                     lhimax = 0
-                end 
+                end
             else
                 dhidt = 100 # 100 is maximum tempdhidt (see setdhidt)
                 lhimax = 0
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
 
     crop.GDDaysToHIo = gddhimax
@@ -2293,7 +2293,7 @@ function adjust_calendar_days!(gvars, iscgcgiven)
     crop.dHIdt = dhidt
 
     return nothing
-end 
+end
 
 
 """
@@ -2303,27 +2303,27 @@ tempprocessing.f90:GDDCDCToCDC:1668
 """
 function gddcdc_to_cdc(plantdaynr, d123, gddl123, gddharvest, ccx, gddcdc, tbase, tupper, notempfiletmin, notempfiletmax, gvars)
     gddi = length_canopy_decline(ccx, gddcdc)
-    if (gddl123+gddi)<=gddharvest 
+    if (gddl123+gddi)<=gddharvest
         cci = 0 # full decline
     else
         # partly decline
-        if gddl123<gddharvest 
+        if gddl123<gddharvest
             gddi = gddharvest - gddl123
         else
             gddi = 5
-        end 
+        end
         # cc at time ti
-        cci = ccx * (1 - 0.05 *(exp(gddi*gddcdc*3.33/(ccx+2.29))-1)) 
-    end 
+        cci = ccx * (1 - 0.05 *(exp(gddi*gddcdc*3.33/(ccx+2.29))-1))
+    end
     ti = sum_calendar_days(gddi, (plantdaynr+d123), tbase, tupper, notempfiletmin, notempfiletmax, gvars)
-    if ti>0 
+    if ti>0
         cdc = ((ccx+2.29)/ti * log(1 + (1-cci/ccx)/0.05))/3.33
     else
         cdc = undef_int
-    end 
+    end
 
     return cdc
-end 
+end
 
 
 """
@@ -2335,23 +2335,23 @@ function adjust_crop_year_to_climfile!(crop::RepCrop, clim_file, clim_record)
     cday1 = crop.Day1
     cdayn = crop.DayN
     dayi, monthi, yeari = determine_date(cday1)
-    if clim_file=="(None)" 
+    if clim_file=="(None)"
         yeari = 1901  # yeari = 1901 if undefined year
     else
         yeari = clim_record.FromY # yeari = 1901 if undefined year
-    end 
+    end
     cday1 = determine_day_nr(dayi, monthi, yeari)
 
     # This function determines Crop.DayN and the string
     cdayn = cday1 + crop.DaysToHarvest - 1
-    if cdayn<cday1 
+    if cdayn<cday1
         cdayn = cday1
     end
 
     crop.Day1 = cday1
     crop.DayN = cdayn
     return nothing
-end 
+end
 
 """
     adjust_climrecord_to!(clim_record::RepClim, cdayn)
@@ -2384,47 +2384,47 @@ function adjust_simperiod!(gvars, projectinput::ProjectInputType)
     inisimfromdaynr = simulation.FromDayNr
     if simulation.LinkCropToSimPeriod
         determine_linked_simday1!(simulation, crop, clim_record, clim_file)
-        if (crop.Day1==simulation.FromDayNr) 
+        if (crop.Day1==simulation.FromDayNr)
             simulation.ToDayNr = crop.DayN
         else
             simulation.ToDayNr = simulation.FromDayNr + 30
-        end 
-        if (clim_file != "(None)") 
-            if (simulation.ToDayNr>clim_record.ToDayNr) 
+        end
+        if (clim_file != "(None)")
+            if (simulation.ToDayNr>clim_record.ToDayNr)
                 simulation.ToDayNr = clim_record.ToDayNr
-            end 
-            if (simulation.ToDayNr<clim_record.FromDayNr) 
+            end
+            if (simulation.ToDayNr<clim_record.FromDayNr)
                 simulation.ToDayNr = clim_record.FromDayNr
-            end 
-        end 
-    else 
-        if (simulation.FromDayNr>crop.Day1) 
+            end
+        end
+    else
+        if (simulation.FromDayNr>crop.Day1)
             simulation.FromDayNr = crop.Day1
-        end 
+        end
         simulation.ToDayNr = crop.DayN
-        if (clim_file != "(None)") & ((simulation.FromDayNr<=clim_record.FromDayNr) | (simulation.FromDayNr>=clim_record.ToDayNr)) 
+        if (clim_file != "(None)") & ((simulation.FromDayNr<=clim_record.FromDayNr) | (simulation.FromDayNr>=clim_record.ToDayNr))
             simulation.FromDayNr = clim_record.FromDayNr
             simulation.ToDayNr = simulation.FromDayNr + 30
-        end 
-    end 
+        end
+    end
 
     # adjust initial depth and quality of the groundwater when required
-    if (!simulparam.ConstGwt) & (inisimfromdaynr != simulation.FromDayNr) 
-        if (groundwater_file != "(None)") 
+    if (!simulparam.ConstGwt) & (inisimfromdaynr != simulation.FromDayNr)
+        if (groundwater_file != "(None)")
             fullfilename = projectinput.ParentDir * "/GroundWater.AqC"
         else
             fullfilename = groundwater_file
-        end 
+        end
         # initialize ZiAqua and ECiAqua
         load_groundwater!(gvars, fullfilename)
         calculate_adjusted_fc!(gvars[:compartments], gvars[:soil_layers], gvars[:integer_parameters][:ziaqua]/100)
-        if gvars[:simulation].IniSWC.AtFC 
+        if gvars[:simulation].IniSWC.AtFC
             reset_swc_to_fc!(gvars[:simulation], gvars[:compartments], gvars[:soil_layers], gvars[:integer_parameters][:ziaqua])
-        end 
-    end 
+        end
+    end
 
     return nothing
-end 
+end
 
 """
     determine_linked_simday1!(simulation::RepSim, crop::RepCrop, clim_record::RepClim, clim_file)
@@ -2433,11 +2433,11 @@ global.f90:DetermineLinkedSimDay1:4694
 """
 function determine_linked_simday1!(simulation::RepSim, crop::RepCrop, clim_record::RepClim, clim_file)
     simday1 = crop.Day1
-    if clim_file != "(None)" 
-        if (simday1<clim_record.FromDayNr) | (simday1>clim_record.ToDayNr) 
+    if clim_file != "(None)"
+        if (simday1<clim_record.FromDayNr) | (simday1>clim_record.ToDayNr)
             simulation.LinkCropToSimPeriod = false
             simday1 = clim_record.FromDayNr
-        end 
+        end
     end
     simulation.FromDayNr = simday1
     return nothing
@@ -2470,26 +2470,26 @@ function load_groundwater!(gvars, groundwater_file)
             if i==0
                 # no groundwater table
                 zcm = undef_int
-                ecdsm = undef_double 
+                ecdsm = undef_double
                 simulparam.ConstGwt = true
                 theend = true
             elseif i==1
                 # constant groundwater table
                 simulparam.ConstGwt = true
             else
-                simulparam.ConstGwt = false 
+                simulparam.ConstGwt = false
             end
 
             # first day of observations (only for variable groundwater table)
-            if !simulparam.ConstGwt 
+            if !simulparam.ConstGwt
                 dayi = parse(Int, split(readline(file))[1])
                 monthi = parse(Int, split(readline(file))[1])
                 year1gwt = parse(Int, split(readline(file))[1])
                 daynr1gwt = determine_day_nr(dayi, monthi, year1gwt)
-            end 
+            end
 
             # single observation (Constant Gwt) or first observation (Variable Gwt)
-            if i>0 
+            if i>0
                 # groundwater table is present
                 readline(file)
                 readline(file)
@@ -2498,33 +2498,33 @@ function load_groundwater!(gvars, groundwater_file)
                 daydouble = parse(Float64, popfirst!(splitedline))
                 z2 = parse(Float64, popfirst!(splitedline))
                 ec2 = parse(Float64, popfirst!(splitedline))
-                if (i==1) | eof(file) 
+                if (i==1) | eof(file)
                     # Constant groundwater table or single observation
                     Zcm = round(Int,100*z2)
                     ecdsm = ec2
                     theend = true
                 else
                     daynr2 = daynr1gwt + round(Int, daydouble) - 1
-                end 
-            end 
+                end
+            end
 
             # other observations
-            if !theend 
+            if !theend
                 # variable groundwater table with more than 1 observation
                 # adjust AtDayNr
                 dayi, monthi, yeari = determine_date(atdaynr_local)
-                if (yeari==1901) & (year1gwt != 1901) 
+                if (yeari==1901) & (year1gwt != 1901)
                     # Make AtDayNr defined
                     atdaynr_local = determine_day_nr(dayi, monthi, year1gwt)
-                end 
-                if (yeari != 1901) & (year1gwt==1901) 
+                end
+                if (yeari != 1901) & (year1gwt==1901)
                     # Make AtDayNr undefined
                     atdaynr_local = determine_day_nr(dayi, monthi, year1gwt)
-                end 
+                end
                 # get observation at AtDayNr
-                if year1gwt != 1901 
+                if year1gwt != 1901
                     # year is defined
-                    if atdaynr_local<=daynr2 
+                    if atdaynr_local<=daynr2
                         zcm = round(Int,100*z2)
                         ecdsm = ec2
                     else
@@ -2537,20 +2537,20 @@ function load_groundwater!(gvars, groundwater_file)
                             z2 = parse(Float64, popfirst!(splitedline))
                             ec2 = parse(Float64, popfirst!(splitedline))
                             daynr2 = daynr1gwt + round(Int, daydouble) - 1
-                            if (atdaynr_local <= daynr2) 
+                            if (atdaynr_local <= daynr2)
                                 zcm, ecdsm =  find_values(atdaynr_local, daynr1, daynr2, z1, ec1, z2, ec2)
                                 theend = true
-                            end 
+                            end
                             if eof(file) & (!theend)
                                 zcm = round(Int,100*z2)
                                 ecdsm = ec2
                                 theend = true
-                            end 
-                        end 
-                    end 
+                            end
+                        end
+                    end
                 else
                     # year is undefined
-                    if (atdaynr_local <= daynr2) 
+                    if (atdaynr_local <= daynr2)
                         daynr2 = daynr2 + 365
                         atdaynr_local = atdaynr_local + 365
                         while !eof(file)
@@ -2559,7 +2559,7 @@ function load_groundwater!(gvars, groundwater_file)
                             z1 = parse(Float64, popfirst!(splitedline))
                             ec1 = parse(Float64, popfirst!(splitedline))
                             daynr1 = daynr1gwt + round(Int, daydouble) - 1
-                        end 
+                        end
                         zcm, ecdsm =  find_values(atdaynr_local, daynr1, daynr2, z1, ec1, z2, ec2)
                     else
                         daynrn = daynr2 + 365
@@ -2574,26 +2574,26 @@ function load_groundwater!(gvars, groundwater_file)
                             z2 = parse(Float64, popfirst!(splitedline))
                             ec2 = parse(Float64, popfirst!(splitedline))
                             daynr2 = daynr1gwt + round(Int, daydouble) - 1
-                            if (atdaynr_local <= daynr2) 
+                            if (atdaynr_local <= daynr2)
                                 zcm, ecdsm =  find_values(atdaynr_local, daynr1, daynr2, z1, ec1, z2, ec2)
                                 theend = true
-                            end 
+                            end
                             if eof(file) & (!theend)
                                 zcm, ecdsm =  find_values(atdaynr_local, daynr2, daynrn, z2, ec2, zn, ecn)
                                 theend = true
-                            end 
-                        end 
-                    end 
-                end 
+                            end
+                        end
+                    end
+                end
                 # variable groundwater table with more than 1 observation
-            end 
+            end
             gvars[:integer_parameters][:ziaqua] = zcm
             gvars[:float_parameters][:eciaqua] = ecdsm
-        end 
+        end
     end
 
-    return nothing 
-end 
+    return nothing
+end
 
 """
     zcn, ecdsm = find_values(atdaynr, daynr1, daynr2, z1, ec1, z2, ec2)
@@ -2604,7 +2604,7 @@ function find_values(atdaynr, daynr1, daynr2, z1, ec1, z2, ec2)
         zcm = round(Int, 100 * (z1 + (z2-z1) * (atdaynr-daynr1)/(daynr2-daynr1)))
         ecdsm = ec1 + (ec2-ec1) * (atdaynr-daynr1)/(daynr2-daynr1)
         return zcm, ecdsm
-end 
+end
 
 
 """
@@ -2616,7 +2616,7 @@ function calculate_adjusted_fc!(compartadj::Vector{CompartmentIndividual}, soil_
     depth = 0
     for compi in eachindex(compartadj)
         depth = depth + compartadj[compi].Thickness
-    end 
+    end
 
     compi = length(compartadj)
 
@@ -2624,27 +2624,27 @@ function calculate_adjusted_fc!(compartadj::Vector{CompartmentIndividual}, soil_
         zi = depth - compartadj[compi].Thickness/2
         xmax = no_adjustment(soil_layers[compartadj[compi].Layer].FC)
 
-        if (depthaquifer<0) | ((depthaquifer - zi)>=xmax) 
+        if (depthaquifer<0) | ((depthaquifer - zi)>=xmax)
             for ic in 1:compi
                 compartadj[ic].FCadj = soil_layers[compartadj[ic].Layer].FC
-            end 
+            end
             compi = 0
         else
             if (soil_layers[compartadj[compi].Layer].FC>=soil_layers[compartadj[compi].Layer].SAT)
                 compartadj[compi].FCadj = soil_layers[compartadj[compi].Layer].FC
             else
-                if (zi >= depthaquifer) 
+                if (zi >= depthaquifer)
                     compartadj[compi].FCadj = soil_layers[compartadj[compi].Layer].SAT
                 else
                     deltav = soil_layers[compartadj[compi].Layer].SAT - soil_layers[compartadj[compi].Layer].FC
                     deltafc = (deltav/(xmax^2)) * (zi - (depthaquifer - xmax))^2
                     compartadj[compi].FCadj = soil_layers[compartadj[compi].Layer].FC + deltafc
-                end 
-            end 
+                end
+            end
             depth = depth - compartadj[compi].Thickness
             compi = compi - 1
-        end 
-    end 
+        end
+    end
 
     return nothing
 end
@@ -2663,15 +2663,15 @@ function no_adjustment(fcvolpr)
     if fcvolpr<=10
         nadj = 1
     else
-        if fcvolpr>=30 
+        if fcvolpr>=30
             nadj = 2
         else
             pf = 2 + 0.3 * (fcvolpr-10)/20
             nadj = (exp(pf*log(10)))/100
-        end 
-    end 
+        end
+    end
     return nadj
-end 
+end
 
 """
     reset_swc_to_fc!(simulation::RepSim, compartments::Vector{CompartmentIndividual},
@@ -2684,31 +2684,31 @@ function reset_swc_to_fc!(simulation::RepSim, compartments::Vector{CompartmentIn
     simulation.IniSWC.AtDepths = false
     if ziaqua<0  # no ground water table
         simulation.IniSWC.NrLoc = length(soil_layers)
-        for layeri = 1:simulation.IniSWC.NrLoc 
+        for layeri = 1:simulation.IniSWC.NrLoc
             simulation.IniSWC.Loc[layeri] = soil_layers[layeri].Thickness
             simulation.IniSWC.VolProc[layeri] = soil_layers[layeri].FC
-            simulation.IniSWC.SaltECe[layeri] = 0 
-        end 
+            simulation.IniSWC.SaltECe[layeri] = 0
+        end
     else
         simulation.IniSWC.NrLoc = length(compartments)
-        for loci = 1:simulation.IniSWC.NrLoc 
+        for loci = 1:simulation.IniSWC.NrLoc
             simulation.IniSWC.Loc[loci] = compartments[loci].Thickness
             simulation.IniSWC.VolProc[loci] = compartments[loci].FCadj
-            simulation.IniSWC.SaltECe[loci] = 0 
-        end 
-    end 
-    for compi in eachindex(compartments) 
+            simulation.IniSWC.SaltECe[loci] = 0
+        end
+    end
+    for compi in eachindex(compartments)
         compartments[compi].Theta = compartments[compi].FCadj/100
         simulation.ThetaIni[compi] = compartments[compi].Theta
         for celli in 1:soil_layers[compartments[compi].Layer].SCP1
             # salinity in cells
             compartments[compi].Salt[celli] = 0
             compartments[compi].Depo[celli] = 0
-        end 
-    end 
+        end
+    end
 
     return nothing
-end 
+end
 
 function reset_swc_to_fc!(simulation::RepSim, compartments::Vector{AbstractParametersContainer},
                            soil_layers::Vector{AbstractParametersContainer}, ziaqua)
@@ -2733,12 +2733,12 @@ function no_irrigation!(gvars)
         gvars[:irri_before_season][nri].Param = 0
         gvars[:irri_after_season][nri].DayNr = 0
         gvars[:irri_after_season][nri].Param = 0
-    end 
-    gvars[:irri_ecw].PreSeason = 0 
-    gvars[:irri_ecw].PostSeason = 0 
+    end
+    gvars[:irri_ecw].PreSeason = 0
+    gvars[:irri_ecw].PostSeason = 0
 
     return nothing
-end 
+end
 
 """
     load_irri_schedule_info!(gvars, irri_file)
@@ -2759,9 +2759,9 @@ function load_irri_schedule_info!(gvars, irri_file)
         elseif i==3
             gvars[:symbol_parameters][:irrimethod] = :MBorder
         elseif i==4
-            gvars[:symbol_parameters][:irrimethod] = :MFurrow 
+            gvars[:symbol_parameters][:irrimethod] = :MFurrow
         else
-            gvars[:symbol_parameters][:irrimethod] = :MDrip 
+            gvars[:symbol_parameters][:irrimethod] = :MDrip
         end
         # fraction of soil surface wetted
         gvars[:simulparam].IrriFwInSeason = parse(Int, split(readline(file))[1])
@@ -2776,16 +2776,16 @@ function load_irri_schedule_info!(gvars, irri_file)
             gvars[:symbol_parameters][:irrimode] = :Generate
         else
             gvars[:symbol_parameters][:irrimode] = :Inet
-        end 
+        end
 
         # 1. Irrigation schedule
         if i == 1
             gvars[:integer_parameters][:irri_first_daynr] = parse(Int, split(readline(file))[1])
-        end 
+        end
 
 
         # 2. Generate
-        if gvars[:symbol_parameters][:irrimode] == :Generate 
+        if gvars[:symbol_parameters][:irrimode] == :Generate
             i = parse(Int, split(readline(file))[1])
             if i==1
                 gvars[:symbol_parameters][:timemode] = :FixInt
@@ -2803,16 +2803,16 @@ function load_irri_schedule_info!(gvars, irri_file)
                 gvars[:symbol_parameters][:depthmode] = :ToFc
             else
                 gvars[:symbol_parameters][:depthmode] = :FixDepth
-            end 
-        end 
+            end
+        end
 
         # 3. Net irrigation requirement
-        if gvars[:symbol_parameters][:irrimode] == :Inet 
+        if gvars[:symbol_parameters][:irrimode] == :Inet
             gvars[:simulparam].PercRAW = parse(Int, split(readline(file))[1])
-        end 
+        end
 
         # 4. If irigation is :Manual or :Generate we read the rest of the file and save in arrays
-        if gvars[:symbol_parameters][:irrimode] == :Manual 
+        if gvars[:symbol_parameters][:irrimode] == :Manual
             readline(file)
             readline(file)
             Irri_1 = Float64[]
@@ -2832,7 +2832,7 @@ function load_irri_schedule_info!(gvars, irri_file)
             setparameter!(gvars[:array_parameters], :Irri_3, Irri_3)
         end
 
-        if gvars[:symbol_parameters][:irrimode] == :Generate 
+        if gvars[:symbol_parameters][:irrimode] == :Generate
             readline(file)
             readline(file)
             readline(file)
@@ -2859,7 +2859,7 @@ function load_irri_schedule_info!(gvars, irri_file)
     end
 
     return nothing
-end 
+end
 
 """
     load_management!(gvars, man_file; kwargs...)
@@ -2867,7 +2867,7 @@ end
 global.f90:LoadManagement:3366
 """
 function load_management!(gvars, man_file; kwargs...)
-    _load_management!(kwargs[:runtype], gvars, man_file) 
+    _load_management!(kwargs[:runtype], gvars, man_file)
     return nothing
 end
 
@@ -2890,11 +2890,11 @@ function _load_management!(runtype::NormalFileRun, gvars, man_file)
         simulation.ECStorageIni = 0
         # surface run-off
         i = parse(Int, split(readline(file))[1])
-        if i==1 
+        if i==1
             management.RunoffOn = false # prevention of surface runoff
         else
             management.RunoffOn = true # surface runoff is not prevented
-        end 
+        end
         management.CNcorrection = parse(Int, split(readline(file))[1])
         # weed infestation
         management.WeedRC = parse(Int, split(readline(file))[1])# relative cover of weeds (%)
@@ -2905,11 +2905,11 @@ function _load_management!(runtype::NormalFileRun, gvars, man_file)
         management.WeedAdj = parse(Int, split(readline(file))[1])
         # multiple cuttings
         i = parse(Int, split(readline(file))[1])
-        if i==0 
+        if i==0
             management.Cuttings.Considered = false
         else
-            management.Cuttings.Considered = true 
-        end 
+            management.Cuttings.Considered = true
+        end
         # Canopy cover (%) after cutting
         management.Cuttings.CCcut = parse(Int, split(readline(file))[1])
         # Next line is expected to be present in the input file, however
@@ -2922,10 +2922,10 @@ function _load_management!(runtype::NormalFileRun, gvars, man_file)
         # (-9 = total growth cycle)
         management.Cuttings.NrDays = parse(Int, split(readline(file))[1])
         i = parse(Int, split(readline(file))[1])
-        if i==1 
+        if i==1
             management.Cuttings.Generate = true
         else
-            management.Cuttings.Generate = false 
+            management.Cuttings.Generate = false
         end
         # Time criterion for generating cuttings
         i = parse(Int, split(readline(file))[1])
@@ -2947,20 +2947,20 @@ function _load_management!(runtype::NormalFileRun, gvars, man_file)
         elseif i==5
             # produced fresh yield (ton/ha)
             management.Cuttings.Criterion = :FreshY
-        end 
+        end
         # final harvest at crop maturity:
         i = parse(Int, split(readline(file))[1])
-        if i==1 
+        if i==1
             management.Cuttings.HarvestEnd = true
         else
             management.Cuttings.HarvestEnd = false
-        end 
+        end
         # dayNr for Day 1 of list of cuttings
         # (-9 = Day1 is start growing cycle)
         management.Cuttings.FirstDayNr = parse(Int, split(readline(file))[1])
     end
     return nothing
-end 
+end
 
 function _load_management!(runtype::T, gvars, man_file) where T<:TomlFileRun
     load_gvars_from_toml!(gvars[:management], man_file)
@@ -2989,7 +2989,7 @@ function _load_management!(runtype::T, gvars, man_file; kwargs...) where T<:NoFi
     simulation.ECStorageIni = 0
     return nothing
 end
-    
+
 """
     adjust_size_compartments!(gvars, cropzx)
 
@@ -3013,20 +3013,20 @@ function adjust_size_compartments!(gvars, cropzx)
     end
 
     # 3. Increase number of compartments (if less than 12)
-    if (length(compartments) < max_no_compartments) 
+    if (length(compartments) < max_no_compartments)
         logi = true
         while logi
             if (cropzx-totdepthc)>simulparam.CompDefThick
                 push!(compartments, CompartmentIndividual(Thickness=simulparam.CompDefThick))
             else
                 push!(compartments, CompartmentIndividual(Thickness=cropzx-totdepthc))
-            end 
+            end
             totdepthc += compartments[end].Thickness
-            if (length(compartments)==max_no_compartments) | ((totdepthc+0.00001)>=cropzx) 
+            if (length(compartments)==max_no_compartments) | ((totdepthc+0.00001)>=cropzx)
                 logi = false
             end
-        end 
-    end 
+        end
+    end
 
     # 4. Adjust size of compartments (if total depth of compartments < rooting depth)
     if (totdepthc+0.00001)<cropzx
@@ -3035,28 +3035,28 @@ function adjust_size_compartments!(gvars, cropzx)
         for i in eachindex(compartments)
             compartments[i].Thickness = round(Int, 20*0.1 * (1 + i*fadd))*0.05
             totdepthc += compartments[i].Thickness
-        end 
-        if totdepthc<cropzx 
+        end
+        if totdepthc<cropzx
             logi = true
             while logi
                 compartments[12].Thickness += 0.05
                 totdepthc += 0.05
-                if totdepthc>=cropzx 
+                if totdepthc>=cropzx
                     logi = false
                 end
-            end 
+            end
         else
             while (totdepthc - 0.04999999)>=cropzx
                 compartments[12].Thickness -= 0.05
                 totdepthc = totdepthc - 0.05
-            end 
-        end 
-    end 
+            end
+        end
+    end
     # 5. Adjust soil water content and theta initial
     prevecdscomp = zero(prevvolprcomp) #OJO this is not declared in fortran code, but it is implicit value is 0 and that is what we do here
     adjust_theta_initial!(gvars, prevnrcomp, prevthickcomp, prevvolprcomp, prevecdscomp)
     return nothing
-end 
+end
 
 """
     adjust_theta_initial!(gvars, prevnrcomp, prevthickcomp, prevvolprcomp, prevecdscomp)
@@ -3072,47 +3072,47 @@ function adjust_theta_initial!(gvars, prevnrcomp, prevthickcomp, prevvolprcomp, 
     totdepthc = 0
     for compi in eachindex(compartments)
         totdepthc += compartments[compi].Thickness
-    end 
+    end
 
     # 2. Stretch thickness of bottom soil layer if required
     totdepthl = 0
     for layeri in eachindex(soil_layers)
         totdepthl += soil_layers[layeri].Thickness
-    end 
-    if totdepthc>totdepthl 
+    end
+    if totdepthc>totdepthl
         soil_layers[end].Thickness += (totdepthc - totdepthl)
-    end 
+    end
 
     # 3. Assign a soil layer to each soil compartment
     designate_soillayer_to_compartments!(compartments, soil_layers)
 
     # 4. Adjust initial Soil Water Content of soil compartments
-    if simulation.ResetIniSWC 
-        if simulation.IniSWC.AtDepths 
+    if simulation.ResetIniSWC
+        if simulation.IniSWC.AtDepths
             translate_inipoints_to_swprofile!(gvars, simulation.IniSWC.NrLoc, simulation.IniSWC.Loc, simulation.IniSWC.VolProc, simulation.IniSWC.SaltECe)
         else
             translate_inilayers_to_swprofile!(gvars, simulation.IniSWC.NrLoc, simulation.IniSWC.Loc, simulation.IniSWC.VolProc, simulation.IniSWC.SaltECe)
-        end 
+        end
     else
-        translate_inilayers_to_swprofile!(gvars, prevnrcomp, prevthickcomp, prevvolprcomp, prevecdscomp) 
-    end 
+        translate_inilayers_to_swprofile!(gvars, prevnrcomp, prevthickcomp, prevvolprcomp, prevecdscomp)
+    end
 
     # 5. Adjust watercontent in soil layers and determine ThetaIni
     for layeri in eachindex(soil_layers)
         soil_layers[layeri].WaterContent = 0
-    end 
+    end
     for compi in eachindex(compartments)
         simulation.ThetaIni[compi] = compartments[compi].Theta
         soil_layers[compartments[compi].Layer].WaterContent += simulation.ThetaIni[compi]*100*10*compartments[compi].Thickness
-    end 
+    end
     total = 0
     for layeri in eachindex(soil_layers)
         total += soil_layers[layeri].WaterContent
-    end 
+    end
     gvars[:total_water_content].BeginDay = total
 
     return nothing
-end 
+end
 
 """
     translate_inipoints_to_swprofile!(gvars, nrloc, locdepth, locvolpr, locecds)
@@ -3130,7 +3130,7 @@ function translate_inipoints_to_swprofile!(gvars, nrloc, locdepth, locvolpr, loc
         compartments[compi].Theta = 0
         compartments[compi].WFactor = 0 # used for salt in (10*volsat*dz * ec)
         totd += compartments[compi].Thickness
-    end 
+    end
     compi = 0
     depthi = 0
     addcomp = true
@@ -3143,14 +3143,14 @@ function translate_inipoints_to_swprofile!(gvars, nrloc, locdepth, locvolpr, loc
         d1 = d2
         th1 = th2
         ec1 = ec2
-        if loci<nrloc 
+        if loci<nrloc
             loci += 1
             d2 = locdepth[loci]
             th2 = locvolpr[loci]
             ec2 = locecds[loci]
         else
             d2 = totd
-        end 
+        end
         # transfer water to compartment (swc in mm) and salt in (10*volsat*dz * ec)
         theend = false
         dtopcomp = d1  # depthi is the bottom depth
@@ -3159,20 +3159,20 @@ function translate_inipoints_to_swprofile!(gvars, nrloc, locdepth, locvolpr, loc
         while !theend
             thtopcomp = thbotcomp
             ectopcomp = ecbotcomp
-            if (addcomp) 
+            if (addcomp)
                 compi = compi + 1
                 depthi = depthi + compartments[compi].Thickness
-            end 
-            if depthi<d2 
+            end
+            if depthi<d2
                 thbotcomp = th1 + (th2-th1)*(depthi-d1)/(d2-d1)
                 compartments[compi].Theta = compartments[compi].Theta + 10*(depthi-dtopcomp)*(thtopcomp+thbotcomp)/2
                 ecbotcomp = ec1 + (ec2-ec1)*(depthi-d1)/(d2-d1)
                 compartments[compi].WFactor = compartments[compi].WFactor + 10*(depthi-dtopcomp)*soil_layers[compartments[compi].Layer].SAT*(ectopcomp+ecbotcomp)/2
                 addcomp = true
                 dtopcomp = depthi
-                if compi==nrcomp 
+                if compi==nrcomp
                     theend = true
-                end 
+                end
             else
                 thbotcomp = th2
                 ecbotcomp = ec2
@@ -3182,29 +3182,29 @@ function translate_inipoints_to_swprofile!(gvars, nrloc, locdepth, locvolpr, loc
                     addcomp = true
                 else
                     addcomp = false
-                end 
+                end
                 theend = true
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
     for compi in eachindex(compartments)
         # from mm(water) to theta and final check
         compartments[compi].Theta = compartments[compi].Theta/(1000*compartments[compi].Thickness)
         if (compartments[compi].Theta>soil_layers[compartments[compi].Layer].SAT/100)
             compartments[compi].Theta = soil_layers[compartments[compi].Layer].SAT/100
-        end 
-        if compartments[compi].Theta<0 
+        end
+        if compartments[compi].Theta<0
             compartments[compi].Theta=0
-        end 
+        end
         # from (10*VolSat*dZ * EC) to ECe and distribution in cellls
         compartments[compi].WFactor = compartments[compi].WFactor/(10*compartments[compi].Thickness*soil_layers[compartments[compi].Layer].SAT)
 
         determine_salt_content!(compartments[compi], soil_layers, simulparam)
-    end 
+    end
 
     return nothing
-end 
+end
 
 """
     determine_salt_content!(compartment::CompartmentIndividual, soil_layers::Vector{SoilLayerIndividual}, simulparam::RepParam)
@@ -3224,21 +3224,21 @@ function determine_salt_content!(compartment::CompartmentIndividual, soil_layers
     for i in 1:soil_layers[compartment.Layer].SCP1
         compartment.Salt[i] = 0
         compartment.Depo[i] = 0
-    end 
+    end
     for i in 1:celn
         sumdf += soil_layers[compartment.Layer].SaltMobility[i]
-    end 
+    end
     for i in 1:celn
         compartment.Salt[i] = totsalt * soil_layers[compartment.Layer].SaltMobility[i]/sumdf
         mm = mm1
-        if i==soil_layers[compartment.Layer].SCP1 
+        if i==soil_layers[compartment.Layer].SCP1
             mm = mmn
         end
         salt_solution_deposit!(compartment, simulparam, i, mm)
-    end 
+    end
 
     return nothing
-end 
+end
 
 function determine_salt_content!(compartment::CompartmentIndividual, soil_layers::Vector{AbstractParametersContainer}, simulparam::RepParam)
     determine_salt_content!(compartment, SoilLayerIndividual[s for s in soil_layers], simulparam)
@@ -3251,16 +3251,16 @@ end
 global.f90:ActiveCells:4257
 """
 function active_cells(compartment::CompartmentIndividual, soil_layers::Vector{SoilLayerIndividual})
-    if compartment.Theta<=soil_layers[compartment.Layer].UL 
+    if compartment.Theta<=soil_layers[compartment.Layer].UL
         celi = 1
         while (compartment.Theta>(soil_layers[compartment.Layer].Dx * celi))
             celi = celi + 1
-        end 
+        end
     else
         celi = soil_layers[compartment.Layer].SCP1
-    end 
+    end
     return celi
-end 
+end
 
 function active_cells(compartment::CompartmentIndividual, soil_layers::Vector{AbstractParametersContainer})
     return active_cells(compartment, SoilLayerIndividual[s for s in soil_layers])
@@ -3276,18 +3276,18 @@ function salt_solution_deposit!(compartment::CompartmentIndividual, simulparam::
     saltdeposit = compartment.Depo[i]
 
     saltsolution = saltsolution + saltdeposit
-    if saltsolution>simulparam.SaltSolub*mm 
+    if saltsolution>simulparam.SaltSolub*mm
         saltdeposit = saltsolution - simulparam.SaltSolub * mm
         saltsolution = simulparam.SaltSolub * mm
     else
         saltdeposit = 0
-    end 
+    end
 
     compartment.Salt[i] = saltsolution
     compartment.Depo[i] = saltdeposit
 
     return nothing
-end 
+end
 
 """
     translate_inilayers_to_swprofile!(gvars, nrlay, laythickness, layvolpr, layecds)
@@ -3304,7 +3304,7 @@ function translate_inilayers_to_swprofile!(gvars, nrlay, laythickness, layvolpr,
     for compi in eachindex(compartments)
         compartments[compi].Theta = 0
         compartments[compi].WFactor = 0  # used for ECe in this procedure
-    end 
+    end
     compi = 0
     sdcomp = 0
     layeri = 1
@@ -3314,7 +3314,7 @@ function translate_inilayers_to_swprofile!(gvars, nrlay, laythickness, layvolpr,
         fracc = 0
         compi = compi + 1
         sdcomp = sdcomp + compartments[compi].Thickness
-        if sdlay>=sdcomp 
+        if sdlay>=sdcomp
             compartments[compi].Theta = compartments[compi].Theta + (1-fracc)*layvolpr[layeri]/100
             compartments[compi].WFactor = compartments[compi].WFactor + (1-fracc)*layecds[layeri]
         else
@@ -3326,36 +3326,36 @@ function translate_inilayers_to_swprofile!(gvars, nrlay, laythickness, layvolpr,
                 compartments[compi].WFactor = compartments[compi].WFactor + fracc*layecds[layeri]
                 fracc = (sdlay - (sdcomp-compartments[compi].Thickness))/(compartments[compi].Thickness)
                 # add next layer
-                if layeri<nrlay 
+                if layeri<nrlay
                     layeri = layeri + 1
                     sdlay = sdlay + laythickness[layeri]
                 else
                     goon = false
-                end 
-            end 
+                end
+            end
             compartments[compi].Theta = compartments[compi].Theta + (1-fracc)*layvolpr[layeri]/100
             compartments[compi].WFactor = compartments[compi].WFactor + (1-fracc)*layecds[layeri]
-        end 
+        end
         # next Compartment
-    end 
+    end
     if  !goon
         for i in (compi+1):length(compartments)
             compartments[i].Theta = layvolpr[nrlay]/100
             compartments[i].WFactor = layecds[nrlay]
-        end 
-    end 
+        end
+    end
 
     # final check of SWC
     for compi in eachindex(compartments)
-        if (compartments[compi].Theta > soil_layers[compartments[compi].Layer].SAT/100) 
+        if (compartments[compi].Theta > soil_layers[compartments[compi].Layer].SAT/100)
             compartments[compi].Theta = soil_layers[compartments[compi].Layer].SAT/100
-        end 
+        end
         # salt distribution in cellls
         determine_salt_content!(compartments[compi], soil_layers, simulparam)
-    end 
+    end
 
     return nothing
-end 
+end
 
 """
      load_initial_conditions!(gvars, swcinifilefull)
@@ -3369,16 +3369,16 @@ function load_initial_conditions!(gvars, swcinifilefull)
     # Keep in mind that this could affect the graphical interface
     open(swcinifilefull, "r") do file
         readline(file)
-        simulation.CCini = parse(Float64, split(readline(file))[1]) 
-        simulation.Bini = parse(Float64, split(readline(file))[1]) 
-        simulation.Zrini = parse(Float64, split(readline(file))[1]) 
+        simulation.CCini = parse(Float64, split(readline(file))[1])
+        simulation.Bini = parse(Float64, split(readline(file))[1])
+        simulation.Zrini = parse(Float64, split(readline(file))[1])
         setparameter!(gvars[:float_parameters], :surfacestorage, parse(Float64, split(readline(file))[1]))
         simulation.ECStorageIni = parse(Float64, split(readline(file))[1])
         i = parse(Int, split(readline(file))[1])
         if i==1
             simulation.IniSWC.AtDepths = true
         else
-            simulation.IniSWC.AtDepths = false 
+            simulation.IniSWC.AtDepths = false
         end
         simulation.IniSWC.NrLoc = parse(Int, split(readline(file))[1])
         readline(file)
@@ -3394,7 +3394,7 @@ function load_initial_conditions!(gvars, swcinifilefull)
     simulation.IniSWC.AtFC = false
 
     return nothing
-end 
+end
 
 """
     ece = ececomp(compartment::CompartmentIndividual, soil_layers::Vector{SoilLayerIndividual}, simulparam::RepParam)
@@ -3406,7 +3406,7 @@ function ececomp(compartment::CompartmentIndividual, soil_layers::Vector{SoilLay
     totsalt = 0
     for i in 1:soil_layers[compartment.Layer].SCP1
         totsalt = totsalt + compartment.Salt[i] + compartment.Depo[i] # g/m2
-    end 
+    end
 
     denominator = volsat*10 * compartment.Thickness * (1 - soil_layers[compartment.Layer].GravelVol/100)
     totsalt = totsalt / denominator  # g/l
@@ -3415,7 +3415,7 @@ function ececomp(compartment::CompartmentIndividual, soil_layers::Vector{SoilLay
         totsalt = simulparam.SaltSolub
     end
     return totsalt / equiv # ds/m
-end 
+end
 
 """
     load_offseason!(gvars, offseason_file)
@@ -3457,31 +3457,31 @@ function load_offseason!(gvars, offseason_file)
             simulation.IrriFwOffSeason = parse(Int, split(readline(file))[1])
 
             # irrigation events - get events before and after season
-            if (nrevents1>0) | (nrevents2>0) 
+            if (nrevents1>0) | (nrevents2>0)
                 for _ in 1:3
                     readline(file)
                 end
-            end 
-            if nrevents1>0 
+            end
+            if nrevents1>0
                 for nri in 1:nrevents1
                     # events BEFORE growing period
                     splitedline = split(readline(file))
                     irri_before_season.DayNr[nri] = parse(Int, popfirst!(splitedline))
                     irri_before_season.Param[nri] = parse(Int, popfirst!(splitedline))
-                end 
-            end 
-            if nrevents2>0 
+                end
+            end
+            if nrevents2>0
                 for nri in 2:nrevents1
                     # events AFTER growing period
                     splitedline = split(readline(file))
                     irri_after_season.DayNr[nri] = parse(Int, popfirst!(splitedline))
                     irri_after_season.Param[nri] = parse(Int, popfirst!(splitedline))
-                end 
-            end 
+                end
+            end
         end
     end
     return nothing
-end 
+end
 
 """
     adjust_compartments!(gvars)
@@ -3497,39 +3497,39 @@ function adjust_compartments!(gvars)
     ziaqua = gvars[:integer_parameters][:ziaqua]
     # Adjust size of compartments if required
     totdepth = 0
-    for i in eachindex(compartments) 
+    for i in eachindex(compartments)
         totdepth += compartments[i].Thickness
-    end 
-    if simulation.MultipleRunWithKeepSWC 
+    end
+    if simulation.MultipleRunWithKeepSWC
         # Project with a sequence of simulation runs and KeepSWC
         if round(Int, simulation.MultipleRunConstZrx*1000)>round(Int,totdepth*1000)
             adjust_size_compartments!(gvars, simulation.MultipleRunConstZrx)
-        end 
+        end
     else
         if round(Int, crop.RootMax*1000)>round(Int,totdepth*1000)
             if round(Int, soil.RootMax*1000)==round(Int, crop.RootMax*1000)
                 # no restrictive soil layer
                 adjust_size_compartments!(gvars, crop.RootMax)
                 # adjust soil water content
-                calculate_adjusted_fc!(compartments, soil_layers, ziaqua/100) 
+                calculate_adjusted_fc!(compartments, soil_layers, ziaqua/100)
                 if simulation.IniSWC.AtFC
-                    reset_swc_to_fc!(simulation, compartments, soil_layers, ziaqua) 
+                    reset_swc_to_fc!(simulation, compartments, soil_layers, ziaqua)
                 end
             else
                 # restrictive soil layer
                 if round(Int, soil.RootMax*1000)>round(Int,totdepth*1000)
                     adjust_size_compartments!(gvars, soil.RootMax)
                     # adjust soil water content
-                    calculate_adjusted_fc!(compartments, soil_layers, ziaqua/100) 
+                    calculate_adjusted_fc!(compartments, soil_layers, ziaqua/100)
                     if simulation.IniSWC.AtFC
-                        reset_swc_to_fc!(simulation, compartments, soil_layers, ziaqua) 
+                        reset_swc_to_fc!(simulation, compartments, soil_layers, ziaqua)
                     end
-                end 
-            end 
-        end 
-    end 
+                end
+            end
+        end
+    end
     return nothing
-end 
+end
 
 """
     reset_previous_sum!(gvars)
@@ -3538,7 +3538,7 @@ run.f90:ResetPreviousSum:3360
 """
 function reset_previous_sum!(gvars)
     gvars[:previoussum] = RepSum()
-    
+
     setparameter!(gvars[:float_parameters], :sumeto, 0.0)
     setparameter!(gvars[:float_parameters], :sumgdd, 0.0)
     setparameter!(gvars[:float_parameters], :previoussumeto, 0.0)
@@ -3546,7 +3546,7 @@ function reset_previous_sum!(gvars)
     setparameter!(gvars[:float_parameters], :previousbmob, 0.0)
     setparameter!(gvars[:float_parameters], :previousbsto, 0.0)
     return nothing
-end 
+end
 
 """
     create_tnxreferencefile!(outputs, gvars; kwargs...)
@@ -3570,24 +3570,24 @@ function create_tnxreferencefile!(outputs, gvars; kwargs...)
         tnxreferenceyear = round(Int, (temperature_record.FromY+temperature_record.ToY)/2)
         if tnxreferenceyear == 1901
             tnxreferenceyear = 2000
-        end 
+        end
         # check number of years for each month
         for monthi in 1:12
             monthnryears[monthi] = nryears
-        end 
+        end
         if nryears > 1
             if temperature_record.FromM > 1
                 for monthi in 1:(temperature_record.FromM-1)
                     monthnryears[monthi] = monthnryears[monthi] - 1
-                end 
+                end
             end
             if temperature_record.ToM < 12
                 for monthi in 12:-1:(temperature_record.ToM+1)
                     monthnryears[monthi] = monthnryears[monthi] - 1
-                end 
-            end 
-        end 
-                
+                end
+            end
+        end
+
         # initialize
         yeari = temperature_record.FromY
         monthi = temperature_record.FromM
@@ -3604,10 +3604,10 @@ function create_tnxreferencefile!(outputs, gvars; kwargs...)
             dayi = DaysInMonth[monthi]
             if isleapyear(yeari) & (monthi==2)
                 dayi = dayi + 1
-            end 
+            end
             enddaynr = determine_day_nr(dayi, monthi, yeari)
-        end 
-            
+        end
+
         # open temperature file
         Tmin = gvars[:array_parameters][:Tmin]
         Tmax = gvars[:array_parameters][:Tmax]
@@ -3625,28 +3625,28 @@ function create_tnxreferencefile!(outputs, gvars; kwargs...)
                 monthdays = monthdays + 1
                 if daynri == enddaynr
                     endmonth = true
-                end 
+                end
             elseif temperature_record.Datatype == :Decadely
                 monthdecs = monthdecs + 1
                 if deci == 3 # OJO deci is 0 or undef_int, so this is nonsense
                     endmonth = true
-                end 
+                end
             elseif temperature_record.Datatype == :Monthly
                 endmonth = true
-            end 
+            end
             if i==length(Tmin)
                 endmonth = true
-            end 
+            end
             # End of Month
             if endmonth
                 # mean monthly values Tmin and Tmax
                 if temperature_record.Datatype == :Daily
-                    sum1 = sum1/monthdays 
-                    sum2 = sum2/monthdays 
+                    sum1 = sum1/monthdays
+                    sum2 = sum2/monthdays
                 elseif temperature_record.Datatype == :Decadely
-                    sum1 = sum1/monthdecs 
-                    sum2 = sum2/monthdecs 
-                end 
+                    sum1 = sum1/monthdecs
+                    sum2 = sum2/monthdecs
+                end
                 monthval1[monthi] = monthval1[monthi] + sum1/monthnryears[monthi] # Tmin
                 monthval2[monthi] = monthval2[monthi] + sum2/monthnryears[monthi] # Tmax
                 # Next month
@@ -3657,7 +3657,7 @@ function create_tnxreferencefile!(outputs, gvars; kwargs...)
                     yeari = yeari + 1
                 else
                     monthi = monthi + 1
-                end 
+                end
                 endmonth = false
                 if temperature_record.Datatype == :Daily
                     # EndDayNr = DayNr of last day in month
@@ -3665,20 +3665,20 @@ function create_tnxreferencefile!(outputs, gvars; kwargs...)
                     dayi = DaysInMonth[monthi]
                     if isleapyear(yeari) & (monthi==2)
                         dayi = dayi + 1
-                    end 
+                    end
                     enddaynr = determine_day_nr(dayi, monthi, yeari)
                 elseif temperature_record.Datatype == :Decadely
                     monthdecs = 0
                     deci = 0
-                end 
-            end 
+                end
+            end
             # Next day, decade, month
             if temperature_record.Datatype == :Daily
                 daynri = daynri + 1
-            end 
-        end 
-    end 
-    
+            end
+        end
+    end
+
     # 3. Create and Save TnxReference File
     if gvars[:bool_parameters][:temperature_file_exists]
         # Determine Name of TnxReference File
@@ -3687,13 +3687,13 @@ function create_tnxreferencefile!(outputs, gvars; kwargs...)
         for monthi in 1:12
             tlow = round(Int, 100*monthval1[monthi])/100
             thigh = round(Int, 100*monthval2[monthi])/100
-            add_output_in_tnxreference12months!(outputs, tlow, thigh) 
-        end 
-    end 
+            add_output_in_tnxreference12months!(outputs, tlow, thigh)
+        end
+    end
 
     setparameter!(gvars[:integer_parameters], :tnxreferenceyear, tnxreferenceyear)
     return nothing
-end 
+end
 
 """
     create_tnxreference365days!(outputs, gvars; kwargs...)
@@ -3701,32 +3701,32 @@ end
 tempprocessing.f90:CreateTnxReference365Days:3089
 """
 function create_tnxreference365days!(outputs, gvars; kwargs...)
-    if length(outputs[:tnxreference12months][:tlow]) > 0 
+    if length(outputs[:tnxreference12months][:tlow]) > 0
         # get data set for 1st month
         monthi = 1
         tmin_dataset, tmax_dataset = get_monthly_temperature_dataset_from_tnxreferencefile(outputs, monthi)
-        
+
         # Tnx for Day 1 to 365
         for daynri in 1:365
             if daynri > tmin_dataset[31].DayNr
                 # next month
                 monthi = monthi + 1
                 tmin_dataset, tmax_dataset = get_monthly_temperature_dataset_from_tnxreferencefile(outputs, monthi)
-            end 
+            end
             i = 1
             while tmin_dataset[i].DayNr != daynri
                 i = i+1
-            end 
+            end
             tlow = round(Int, 100*tmin_dataset[i].Param)/100
             thigh = round(Int, 100*tmax_dataset[i].Param)/100
             add_output_in_tnxreference365days!(outputs, tlow, thigh)
-        end 
-    end 
+        end
+    end
 
     # after this we do not use tnxreference12months so we flush it
     flush_output_tnxreference12months!(outputs)
     return nothing
-end 
+end
 
 """
     tmin_dataset, tmax_dataset = get_monthly_temperature_dataset_from_tnxreferencefile(monthi)
@@ -3743,13 +3743,13 @@ function get_monthly_temperature_dataset_from_tnxreferencefile(outputs, monthi)
         c1min, c1max = read_output_from_tnxreference12months(outputs, 12)
     else
         c1min, c1max = read_output_from_tnxreference12months(outputs, monthi - 1)
-    end 
+    end
     c2min, c2max = read_output_from_tnxreference12months(outputs, monthi)
     if monthi == 12
         c3min, c3max = read_output_from_tnxreference12months(outputs, 1)
     else
         c3min, c3max = read_output_from_tnxreference12months(outputs, monthi + 1)
-    end 
+    end
 
     c1min = c1min*ni
     c1max = c1max*ni
@@ -3772,13 +3772,13 @@ function get_monthly_temperature_dataset_from_tnxreferencefile(outputs, monthi)
         tmin_dataset[dayi].Param = aover3min*(t2*t2*t2-t1*t1*t1) + bover2min*(t2*t2-t1*t1) + cmin*(t2-t1)
         tmax_dataset[dayi].Param = aover3max*(t2*t2*t2-t1*t1*t1) + bover2max*(t2*t2-t1*t1) + cmax*(t2-t1)
         t1 = t2
-    end 
+    end
     for dayi in (dayn+1):31 # give to remaining days (day 29,30 or 31) the daynr of the last day of the month
         tmin_dataset[dayi].DayNr = dnr+dayn-1
         tmax_dataset[dayi].DayNr = dnr+dayn-1
         tmin_dataset[dayi].Param = 0
         tmax_dataset[dayi].Param = 0
-    end 
+    end
 
     return tmin_dataset, tmax_dataset
-end  
+end

--- a/src/loadvardict.jl
+++ b/src/loadvardict.jl
@@ -30,7 +30,7 @@ end
     set_soil!(soil::RepSoil, soil_type::AbstractString; aux::Union{AbstractDict, Nothing}=nothing)
 
 sets soil for a given soil_type
-possible soil_type are 
+possible soil_type are
 ["sandy clay", "clay", "clay loam", "loamy sand", "loam", "sand", "silt", "silty loam", "silty clay",
 "sandy clay loam", "sandy loam", "silty clay loam", "paddy"]
 """
@@ -92,13 +92,13 @@ function set_soil!(soil::RepSoil, soil_type::AbstractString; aux::Union{Abstract
         soil.NrSoilLayers = 1
     elseif soil_type == "silty clay loam"
         # aquacrop version 6.0
-        soil.CNValue = 72  
+        soil.CNValue = 72
         soil.REW = 13
         soil.NrSoilLayers = 1
     elseif soil_type == "paddy"
         # aquacrop version 6.0
         soil.CNValue = 77
-        soil.REW = 10     
+        soil.REW = 10
         soil.NrSoilLayers = 2
     end
 
@@ -115,7 +115,7 @@ end
     set_soillayers!(soil_layers::Vector{SoilLayerIndividual}, soil_type::AbstractString; aux::Union{AbstractDict, Nothing}=nothing)
 
 sets soil_layers for a given soil_type
-possible soil_type are 
+possible soil_type are
 ["sandy clay", "clay", "clay loam", "loamy sand", "loam", "sand", "silt", "silty loam", "silty clay",
 "sandy clay loam", "sandy loam", "silty clay loam", "paddy"]
 """
@@ -247,7 +247,7 @@ function set_soillayers!(soil_layers::Vector{SoilLayerIndividual}, soil_type::Ab
         soil_layers[1].SAT = 41
         soil_layers[1].FC = 22
         soil_layers[1].WP = 10
-        soil_layers[1].InfRate = 1200 
+        soil_layers[1].InfRate = 1200
         soil_layers[1].Penetrability = 100
         soil_layers[1].GravelMass = 0
         soil_layers[1].CRa = -0.323200
@@ -259,7 +259,7 @@ function set_soillayers!(soil_layers::Vector{SoilLayerIndividual}, soil_type::Ab
         soil_layers[1].SAT = 52
         soil_layers[1].FC = 44
         soil_layers[1].WP = 23
-        soil_layers[1].InfRate = 150 
+        soil_layers[1].InfRate = 150
         soil_layers[1].Penetrability = 100
         soil_layers[1].GravelMass = 0
         soil_layers[1].CRa = -0.516600
@@ -271,7 +271,7 @@ function set_soillayers!(soil_layers::Vector{SoilLayerIndividual}, soil_type::Ab
         soil_layers[1].SAT = 54
         soil_layers[1].FC = 50
         soil_layers[1].WP = 32
-        soil_layers[1].InfRate = 15 
+        soil_layers[1].InfRate = 15
         soil_layers[1].Penetrability = 100
         soil_layers[1].GravelMass = 0
         soil_layers[1].CRa = -0.624600
@@ -282,7 +282,7 @@ function set_soillayers!(soil_layers::Vector{SoilLayerIndividual}, soil_type::Ab
         soil_layers[2].SAT = 55
         soil_layers[2].FC = 54
         soil_layers[2].WP = 39
-        soil_layers[2].InfRate = 2 
+        soil_layers[2].InfRate = 2
         soil_layers[2].Penetrability = 100
         soil_layers[2].GravelMass = 0
         soil_layers[2].CRa = -0.635000
@@ -308,7 +308,7 @@ end
     set_crop!(crop::RepCrop, crop_type::AbstractString; aux::Union{AbstractDict, Nothing}=nothing)
 
 sets crop for a given crop_type
-possible crop_type are 
+possible crop_type are
 ["maize", "wheat", "cotton", "alfalfaGDD", "barley", "barleyGDD", "cottonGDD", "drybean", "drybeanGDD",
 "maizeGDD", "wheatGDD", "sugarbeet", "sugarbeetGDD", "sunflower", "sunflowerGDD", "sugarcane",
 "tomato", "tomatoGDD", "potato", "potatoGDD", "quinoa", "tef", "soybean", "soybeanGDD",
@@ -1505,7 +1505,7 @@ function set_crop!(crop::RepCrop, crop_type::AbstractString; aux::Union{Abstract
         crop.Assimilates.Period = 0         # Number of days at end of season during which assimilates are stored in root system
         crop.Assimilates.Stored = 0         # Percentage of assimilates transferred to root system at last day of season
         crop.Assimilates.Mobilized = 0         # Percentage of stored assimilates transferred to above ground parts in next season
-    elseif crop_type == "sunflowerGDD"         
+    elseif crop_type == "sunflowerGDD"
         # Default Sunflower, GDD (Cordoba, 15Apr86)
         # 7.0       # AquaCrop Version (June 2021)
         # skip this line 0         # File protected
@@ -2696,7 +2696,7 @@ function set_crop!(crop::RepCrop, crop_type::AbstractString; aux::Union{Abstract
         crop.Assimilates.Stored = 0         # Percentage of assimilates transferred to root system at last day of season
         crop.Assimilates.Mobilized = 0         # Percentage of stored assimilates transferred to above ground parts in next season
     elseif crop_type == "rapeseed"
-        # based on default Sunflower acea_crops.py and 
+        # based on default Sunflower acea_crops.py and
         # Zeleke, K. T., Luckett, D. & Cowley, R. Calibration and Testing of the FAO AquaCrop Model for Canola. Agronomy Journal 103, 1610–1618 (2011).
         # skip this line 0         # File protected
         crop.subkind = :Grain # 2         #.. fruit/grain producing crop
@@ -2781,7 +2781,7 @@ function set_crop!(crop::RepCrop, crop_type::AbstractString; aux::Union{Abstract
         crop.Assimilates.Stored = 0         # Percentage of assimilates transferred to root system at last day of season
         crop.Assimilates.Mobilized = 0         # Percentage of stored assimilates transferred to above ground parts in next season
     elseif crop_type == "oat"
-        # Based on Wheat, acea_crops.py and 
+        # Based on Wheat, acea_crops.py and
         # Yuan, M. et al. Assessment of crop growth and water productivity for five C3 species in semi-arid Inner Mongolia. Agricultural Water Management 122, 28–38 (2013).
         # skip this line 0         # File protected
         crop.subkind = :Grain # 2         #.. fruit/grain producing crop
@@ -2904,7 +2904,7 @@ end
     set_perennial_period!(perennial_period::RepPerennialPeriod, crop_type::AbstractString; aux::Union{AbstractDict, Nothing}=nothing)
 
 sets perennial_period for a given crop_type
-possible crop_type are 
+possible crop_type are
 ["maize", "wheat", "cotton", "alfalfaGDD", "barley", "barleyGDD", "cottonGDD", "drybean", "drybeanGDD",
 "maizeGDD", "wheatGDD", "sugarbeet", "sugarbeetGDD", "sunflower", "sunflowerGDD", "sugarcane",
 "tomato", "tomatoGDD", "potato", "potatoGDD", "quinoa", "tef", "soybean", "soybeanGDD",
@@ -3013,7 +3013,7 @@ end
 """
 function load_resultsparameters_from_vardict(; kwargs...)
     aggregationresultsparameters = ParametersContainer(Int)
-    setparameter!(aggregationresultsparameters, :outputaggregate, 0) # only print at the end of seasonout 
+    setparameter!(aggregationresultsparameters, :outputaggregate, 0) # only print at the end of seasonout
 
     dailyresultsparameters = ParametersContainer(Bool)
     setparameter!(dailyresultsparameters, :out1Wabal, true)
@@ -3059,5 +3059,5 @@ function set_clim_record!(record::RepClim; kwargs...)
         actualize_with_dict!(record, kwargs[clim_symbol])
     end
 
-    return nothing 
+    return nothing
 end

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -193,7 +193,7 @@ function start_outputs()
         "IrriInt" => Quantity{Float64, 𝐓, FreeUnits{(d_,), 𝐓, nothing}}[],
     )
 
-    return Dict( 
+    return Dict(
         :logger => logger,
         :tcropsim => tcropsim,
         :etodatasim => etodatasim,
@@ -240,7 +240,7 @@ end
 """
 function add_output_in_tcropsim!(outputs, tlow::T, thigh::T) where T<:Number
     push!(outputs[:tcropsim][:tlow], tlow)
-    push!(outputs[:tcropsim][:thigh], thigh) 
+    push!(outputs[:tcropsim][:thigh], thigh)
     return nothing
 end
 
@@ -315,7 +315,7 @@ end
 """
 function add_output_in_tempdatasim!(outputs, tlow::T, thigh::T) where T<:Number
     push!(outputs[:tempdatasim][:tlow], tlow)
-    push!(outputs[:tempdatasim][:thigh], thigh) 
+    push!(outputs[:tempdatasim][:thigh], thigh)
     return nothing
 end
 
@@ -501,7 +501,7 @@ function add_output_in_dayout!(outputs, arr)
             "SaltZ" => arr[58]*ton*u"ha^-1",
             "ECe" => arr[59]*u"dS/m",
             "ECsw" => arr[60]*u"dS/m",
-            "StSalt_" => arr[61], 
+            "StSalt_" => arr[61],
             "ECgw" => arr[62]*u"dS/m",
             "WC_1" => arr[63],
             "WC_2" => arr[64],
@@ -599,7 +599,7 @@ end
 """
 function add_output_in_tnxreference12months!(outputs, tlow::T, thigh::T) where T<:Number
     push!(outputs[:tnxreference12months][:tlow], tlow)
-    push!(outputs[:tnxreference12months][:thigh], thigh) 
+    push!(outputs[:tnxreference12months][:thigh], thigh)
     return nothing
 end
 
@@ -625,7 +625,7 @@ end
 """
 function add_output_in_tnxreference365days!(outputs, tlow::T, thigh::T) where T<:Number
     push!(outputs[:tnxreference365days][:tlow], tlow)
-    push!(outputs[:tnxreference365days][:thigh], thigh) 
+    push!(outputs[:tnxreference365days][:thigh], thigh)
     return nothing
 end
 
@@ -651,7 +651,7 @@ end
 """
 function add_output_in_tcropreferencesim!(outputs, tlow::T, thigh::T) where T<:Number
     push!(outputs[:tcropreferencesim][:tlow], tlow)
-    push!(outputs[:tcropreferencesim][:thigh], thigh) 
+    push!(outputs[:tcropreferencesim][:thigh], thigh)
     return nothing
 end
 

--- a/src/readtoml.jl
+++ b/src/readtoml.jl
@@ -13,20 +13,20 @@ function load_gvars_from_toml!(simulparam::RepParam, auxparfile; kwargs...)
     end
 
     i = aux["simulparam"]["EffectiveRain"]["method"]
-    if i == 0 
+    if i == 0
         aux["simulparam"]["EffectiveRain"]["method"] = :Full
-    elseif i == 1 
+    elseif i == 1
         aux["simulparam"]["EffectiveRain"]["method"] = :USDA
-    elseif i == 2 
+    elseif i == 2
         aux["simulparam"]["EffectiveRain"]["method"] = :Percentage
     end
 
     i = aux["simulparam"]["CNcorrection"]
-    if i == 1 
+    if i == 1
         aux["simulparam"]["CNcorrection"] = true
     else
         aux["simulparam"]["CNcorrection"] = false
-    end 
+    end
 
     actualize_with_dict!(simulparam, aux["simulparam"])
     return nothing
@@ -42,7 +42,7 @@ end
 function load_gvars_from_toml!(soil_layers::Vector{SoilLayerIndividual}, auxparfile; kwargs...)
     aux = TOML.parsefile(auxparfile)
 
-    for i in eachindex(aux["soil_layers"]) 
+    for i in eachindex(aux["soil_layers"])
         soillayer = SoilLayerIndividual()
 
         actualize_with_dict!(soillayer, aux["soil_layers"][i])
@@ -63,9 +63,9 @@ function load_gvars_from_toml!(record::RepClim, auxparfile; kwargs...)
 
     ni = aux[key]["Datatype"]
     if ni == 1
-       aux[key]["Datatype"] = :Daily 
+       aux[key]["Datatype"] = :Daily
     elseif ni == 2
-       aux[key]["Datatype"] = :Decadely 
+       aux[key]["Datatype"] = :Decadely
     else
        aux[key]["Datatype"] = :Monthly
     end
@@ -78,7 +78,7 @@ end
 
 function load_gvars_from_toml!(management::RepManag, auxparfile; kwargs...)
     aux = TOML.parsefile(auxparfile)
-    
+
     i = aux["management"]["RunoffOn"]
     if i == 1
         aux["management"]["RunoffOn"] = false
@@ -93,11 +93,11 @@ function load_gvars_from_toml!(management::RepManag, auxparfile; kwargs...)
         aux["management"]["Cuttings"]["Criterion"] = :IntDay
     elseif i==2
         aux["management"]["Cuttings"]["Criterion"] = :IntGDD
-    elseif i==3 
+    elseif i==3
         aux["management"]["Cuttings"]["Criterion"] = :DryB
-    elseif i==4 
+    elseif i==4
         aux["management"]["Cuttings"]["Criterion"] = :DryY
-    elseif i==5 
+    elseif i==5
         aux["management"]["Cuttings"]["Criterion"] = :FreshY
     end
 
@@ -123,9 +123,9 @@ function load_gvars_from_toml!(crop::RepCrop, auxparfile; kwargs...)
     xx = aux["crop"]["Planting"]
     if xx==1
         aux["crop"]["Planting"] = :Seed
-    elseif xx==0 
+    elseif xx==0
         aux["crop"]["Planting"] = :Transplant
-    elseif xx==-9 
+    elseif xx==-9
         aux["crop"]["Planting"] = :Regrowth
     else
         aux["crop"]["Planting"] = :Seed
@@ -149,7 +149,7 @@ function load_gvars_from_toml!(crop::RepCrop, auxparfile; kwargs...)
     if xx==1
         aux["crop"]["Assimilates"]["On"] = true
     else
-        aux["crop"]["Assimilates"]["On"] = false 
+        aux["crop"]["Assimilates"]["On"] = false
     end
 
     xx = aux["crop"]["DeterminancyLinked"]
@@ -175,7 +175,7 @@ function load_gvars_from_toml!(crop::RepCrop, auxparfile; kwargs...)
         (crop.StressResponse.ShapeWP>24.9) & (crop.StressResponse.ShapeCDecline>24.9))
         crop.StressResponse.Calibrated = false
     else
-        crop.StressResponse.Calibrated = true 
+        crop.StressResponse.Calibrated = true
     end
 
     if crop.RootMin > crop.RootMax
@@ -195,7 +195,7 @@ function load_gvars_from_toml!(crop::RepCrop, auxparfile; kwargs...)
         crop.GDDLengthFlowering = 0
     end
 
-    
+
     return nothing
 end
 
@@ -210,7 +210,7 @@ function load_gvars_from_toml!(perennial_period::RepPerennialPeriod, auxparfile;
     if xx==0
         aux["perennial_period"]["GenerateOnset"] = false
     else
-        aux["perennial_period"]["GenerateOnset"] = true 
+        aux["perennial_period"]["GenerateOnset"] = true
         if xx==12
             aux["perennial_period"]["OnsetCriterion"] = :TMeanPeriod
         elseif xx==13
@@ -225,7 +225,7 @@ function load_gvars_from_toml!(perennial_period::RepPerennialPeriod, auxparfile;
     if xx==0
         aux["perennial_period"]["GenerateEnd"] = false
     else
-        aux["perennial_period"]["GenerateEnd"] = true 
+        aux["perennial_period"]["GenerateEnd"] = true
         if xx==62
             aux["perennial_period"]["EndCriterion"] = :TMeanPeriod
         elseif xx==63
@@ -246,20 +246,20 @@ function load_gvars_from_toml!(perennial_period::RepPerennialPeriod, auxparfile;
         perennial_period.EndOccurrence = 3
     end
 
-    return nothing 
+    return nothing
 end
 
 function load_resultsparameters_from_toml(auxparfile)
     aux = TOML.parsefile(auxparfile)
-    
+
     dailyresultsparameters = aux["resultsparameters"]["dailyresultsparameters"]
-    if ( dailyresultsparameters["out1Wabal"] | dailyresultsparameters["out2Crop"] 
+    if ( dailyresultsparameters["out1Wabal"] | dailyresultsparameters["out2Crop"]
         | dailyresultsparameters["out3Prof"] | dailyresultsparameters["out4Salt"]
         | dailyresultsparameters["out5CompWC"] | dailyresultsparameters["out6CompEC"]
         | dailyresultsparameters["out7Clim"])
         aux["resultsparameters"]["dailyresultsparameters"]["outdaily"] = true
     else
-        aux["resultsparameters"]["dailyresultsparameters"]["outdaily"] = false 
+        aux["resultsparameters"]["dailyresultsparameters"]["outdaily"] = false
     end
 
     aggregationresultsparameters = aux["resultsparameters"]["aggregationresultsparameters"]
@@ -296,7 +296,7 @@ function load_projectfilenames_from_toml(auxparfile)
     return aux["project_filenames"]
 end
 
-function load_projectinput_from_toml(auxparfile, parentdir) 
+function load_projectinput_from_toml(auxparfile, parentdir)
     aux = TOML.parsefile(auxparfile)
     projectinput = ProjectInputType[]
     for i in eachindex(aux["projectinput"])

--- a/src/startunit.jl
+++ b/src/startunit.jl
@@ -83,7 +83,7 @@ function initialize_project(outputs, theprojectfile, theprojecttype, filepaths; 
                     auxparfile = joinpath(filepaths[:param], theprojectfile[1:end-3] * "PP1")
                 elseif typeof(kwargs[:runtype]) == TomlFileRun
                     auxparfile = testfile
-                elseif typeof(kwargs[:runtype]) == NoFileRun 
+                elseif typeof(kwargs[:runtype]) == NoFileRun
                     auxparfile = ""
                     if haskey(kwargs, :simulparam)
                         actualize_with_dict!(gvars[:simulparam], kwargs[:simulparam])
@@ -196,7 +196,7 @@ end
 
 """
     finalize_run1!(outputs, gvars, nrrun; kwargs...)
-    
+
 run.f90:FinalizeRun1:7376
 """
 function finalize_run1!(outputs, gvars, nrrun; kwargs...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -62,7 +62,7 @@ abstract type AbstractAllOk <: AbstractInfo end
     all_ok = AllOk(logi::Bool, msg::String)
 
 If the simulation is going well then `all_ok.logi == true`
-otherwise `all_ok.logi = false` and the error message is 
+otherwise `all_ok.logi = false` and the error message is
 stored in `all_ok.msg`
 """
 mutable struct AllOk <: AbstractAllOk
@@ -92,11 +92,11 @@ function Base.isapprox(a::T, b::T; kwargs...) where T<:AbstractParametersContain
             ans = false
         end
     end
-    return ans 
+    return ans
 end
 
 
-function Base.isapprox(a::Vector{T}, b::Vector{T}; kwargs...) where {T<:AbstractParametersContainer} 
+function Base.isapprox(a::Vector{T}, b::Vector{T}; kwargs...) where {T<:AbstractParametersContainer}
     all([Base.isapprox(aa, bb; kwargs...) for (aa, bb) in zip(a, b)])
 end
 
@@ -114,7 +114,7 @@ function ParametersContainer(::Type{T}) where {T}
     ParametersContainer(Dict{Symbol,T}())
 end
 
-Base.isapprox(a::Dict{Symbol, T}, b::Dict{Symbol, T}; kwargs...) where {T} = begin 
+Base.isapprox(a::Dict{Symbol, T}, b::Dict{Symbol, T}; kwargs...) where {T} = begin
     if length(a) != length(b)
         ans = false
         println("\n\n\n")
@@ -136,14 +136,14 @@ Base.isapprox(a::Dict{Symbol, T}, b::Dict{Symbol, T}; kwargs...) where {T} = beg
             ans = false
         end
     end
-    return ans 
+    return ans
 end
 
 
 """
     setparameter!(parameterscontainer::ParametersContainer{T}, parameterkey::Symbol, parameter::T)
 
-sets an entry in parameterscontainer. 
+sets an entry in parameterscontainer.
 """
 function setparameter!(parameterscontainer::ParametersContainer{T}, parameterkey::Symbol, parameter::T1) where {T, T1}
     parameterscontainer.parameters[parameterkey] = T(parameter)
@@ -393,7 +393,7 @@ end
 """
     crop = RepCrop()
 
-set from 
+set from
 defaultcropsoil.f90:ResetDefaultCrop:140
 """
 @kwdef mutable struct RepCrop <: AbstractParametersContainer
@@ -639,9 +639,9 @@ end
 """
 @kwdef mutable struct RepEffectStress <: AbstractParametersContainer
     "Reduction of CGC (%)"
-    RedCGC::Int = 0 
+    RedCGC::Int = 0
     "Reduction of CCx (%)"
-    RedCCX::Int = 0 
+    RedCCX::Int = 0
     "Reduction of WP (%)"
     RedWP::Int = undef_int
     "Average decrease of CCx in mid season (%/day)"
@@ -1253,7 +1253,7 @@ end
 """
     cut_info = RepCutInfoRecord()
 """
-@kwdef mutable struct RepCutInfoRecord <: AbstractParametersContainer 
+@kwdef mutable struct RepCutInfoRecord <: AbstractParametersContainer
     "Undocumented"
     NoMoreInfo::Bool=undef_bool
     "Undocumented"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,7 @@ Base.isapprox(a::Symbol, b::Symbol; kwargs...) = isequal(a, b)
 Base.isapprox(a::String, b::String; kwargs...) = isequal(a, b)
 
 """
-    day_nr = determine_day_nr(dayi, monthi, yeari) 
+    day_nr = determine_day_nr(dayi, monthi, yeari)
 
 global.f90:DetermineDayNr:2404
 """
@@ -34,7 +34,7 @@ function determine_date(day_nr::Int)
             break
         end
         monthi = monthi + 1
-    end 
+    end
     dayi = round(Int, sum_day_month - ElapsedDays[monthi] + 0.25 + 0.06)
     return dayi, monthi, yeari
 end
@@ -58,9 +58,9 @@ global.f90:LeapYear:7137
 """
 function isleapyear(year)
     leapyear = false
-    if (year/4 - floor(year/4) <= 0.01) 
+    if (year/4 - floor(year/4) <= 0.01)
         leapyear = true
-    end 
+    end
     return leapyear
 end
 

--- a/test/api_advanced_tests.jl
+++ b/test/api_advanced_tests.jl
@@ -1,6 +1,6 @@
 using AquaCrop
 using Test
-    
+
 using DataFrames
 using Dates
 using StableRNGs
@@ -11,13 +11,13 @@ rng = StableRNG(42)
 function create_mock_climate_dataframe(start_date::Date, end_date::Date, tmin, delta_t, eto, rain)
     # Generate the date range
     dates = collect(start_date:end_date)
-    
+
     # Generate random climate columns (each column has the same number of rows as the date range)
     Tmin = tmin .+ rand(rng, length(dates))
     Tmax = Tmin .+ delta_t .+ rand(rng, length(dates))
     ETo = eto .* abs.(randn(rng, length(dates)))
     Rain = rain .* abs.(randn(rng, length(dates)))
-    
+
     # Create the DataFrame
     df = DataFrame(
         Date = dates,
@@ -26,7 +26,7 @@ function create_mock_climate_dataframe(start_date::Date, end_date::Date, tmin, d
         ETo = ETo,
         Rain = Rain
     )
-    
+
     return df
 end
 
@@ -68,7 +68,7 @@ end
 
 
         ## Optional keyworkds
-        
+
         # Climate
         Tmin = df.Tmin,
         Tmax = df.Tmax,
@@ -129,10 +129,10 @@ end
     df_new = create_mock_climate_dataframe(date_now, end_date, tmin, delta_t, eto, rain)
     change_climate_data!(cropfield, df_new; kwargs...)
     @testset "change climate date cropfield" begin
-        @test isapprox(cropfield.gvars[:float_parameters][:eto], df_new.ETo[1]) 
-        @test isapprox(cropfield.gvars[:float_parameters][:rain], df_new.Rain[1]) 
-        @test isapprox(cropfield.gvars[:float_parameters][:tmin], df_new.Tmin[1]) 
-        @test isapprox(cropfield.gvars[:float_parameters][:tmax], df_new.Tmax[1]) 
+        @test isapprox(cropfield.gvars[:float_parameters][:eto], df_new.ETo[1])
+        @test isapprox(cropfield.gvars[:float_parameters][:rain], df_new.Rain[1])
+        @test isapprox(cropfield.gvars[:float_parameters][:tmin], df_new.Tmin[1])
+        @test isapprox(cropfield.gvars[:float_parameters][:tmax], df_new.Tmax[1])
     end
 
     # run until end of season

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -8,13 +8,13 @@ using Test
     outputs = basic_run(; runtype=runtype, parentdir=parentdir)
     @test isequal(size(outputs[:dayout]), (892, 89))
 
-    # basic run with TomlFileRun 
+    # basic run with TomlFileRun
     runtype = TomlFileRun()
     parentdir = AquaCrop.test_toml_dir  #".../AquaCrop/test/testcase/TOML_FILES"
     outputs = basic_run(; runtype=runtype, parentdir=parentdir)
     @test isequal(size(outputs[:dayout]), (892, 89))
 
-    # basic run with no runtype 
+    # basic run with no runtype
     parentdir = AquaCrop.test_dir  #".../AquaCrop/test/testcase"
     outputs = basic_run(; parentdir=parentdir)
     @test isequal(size(outputs[:dayout]), (892, 89))
@@ -22,13 +22,13 @@ using Test
 
     # basic run with no parentdir, bad directory so no result
     runtype = TomlFileRun()
-    outputs = basic_run(; runtype=runtype) 
+    outputs = basic_run(; runtype=runtype)
     @test isequal(size(outputs[:dayout]), (0, 89))
     @test isequal(outputs[:logger][2], "using default parentdir pwd()")
 end
 
 @testset "Start cropfield intermediate" begin
-    # good start of cropfield using NormalFileRun 
+    # good start of cropfield using NormalFileRun
     runtype = NormalFileRun()
     parentdir = AquaCrop.test_dir  #".../AquaCrop/test/testcase"
     cropfield, all_ok = start_cropfield(; runtype=runtype, parentdir=parentdir)
@@ -58,23 +58,23 @@ end
     @test isapprox( dryyield(cropfield).val, 0.0 )
 
 
-    # bad start giving wrong runtype 
+    # bad start giving wrong runtype
     runtype = :TomlFileRun  # or other thing
     parentdir = AquaCrop.test_toml_dir  #".../AquaCrop/test/testcase/TOML_FILES"
     cropfield, all_ok = start_cropfield(; runtype=runtype, parentdir=parentdir)
     @test isequal(all_ok.logi, false)
     @test isequal(all_ok.msg, "invalid runtype "*string(runtype))
 
-    # bad start giving not real parentdir 
-    runtype = TomlFileRun()  
-    parentdir = "/Not/real/directory" 
+    # bad start giving not real parentdir
+    runtype = TomlFileRun()
+    parentdir = "/Not/real/directory"
     cropfield, all_ok = start_cropfield(; runtype=runtype, parentdir=parentdir)
     @test isequal(all_ok.logi, false)
     @test isequal(all_ok.msg, "invalid parentdir")
 
     # bad start giving real parentdir but with bad  data
-    runtype = TomlFileRun()  
-    parentdir = pwd() 
+    runtype = TomlFileRun()
+    parentdir = pwd()
     cropfield, all_ok = start_cropfield(; runtype=runtype, parentdir=parentdir)
     @test isequal(all_ok.logi, false)
     @test isequal(all_ok.msg, "no project loaded")
@@ -83,7 +83,7 @@ end
 end
 
 # @testset "Setup cropfield intermediate" begin
-#     # good setup of cropfield using NormalFileRun 
+#     # good setup of cropfield using NormalFileRun
 #     runtype = NormalFileRun()
 #     parentdir = AquaCrop.test_dir  #".../AquaCrop/test/testcase"
 #     cropfield, all_ok = start_cropfield(; runtype=runtype, parentdir=parentdir)
@@ -110,7 +110,7 @@ end
 # end
 
 @testset "Update cropfield intermediate" begin
-    # good update of cropfield using NormalFileRun 
+    # good update of cropfield using NormalFileRun
     runtype = NormalFileRun()
     parentdir = AquaCrop.test_dir  #".../AquaCrop/test/testcase"
     cropfield, all_ok = start_cropfield(; runtype=runtype, parentdir=parentdir)

--- a/test/checkpoints.jl
+++ b/test/checkpoints.jl
@@ -1,4 +1,4 @@
-using AquaCrop 
+using AquaCrop
 
 function checkpoint1()
     # Local variables
@@ -126,7 +126,7 @@ function checkpoint1()
         MultipleRun=false,
         NrRuns=1,
         MultipleRunWithKeepSWC=false,
-        MultipleRunConstZrx=AquaCrop.undef_double,#-9, 
+        MultipleRunConstZrx=AquaCrop.undef_double,#-9,
         IrriECw=0,
         DayAnaero=0,
         EffectStress=AquaCrop.RepEffectStress(
@@ -359,7 +359,7 @@ function checkpoint1()
         GenerateOn=false,
         GenerateTempOn=false,
         Criterion=:RainPeriod, #1,
-        AirTCriterion=:CumulGDD, #3, 
+        AirTCriterion=:CumulGDD, #3,
         StartSearchDayNr=1,
         StopSearchDayNr=0,
         LengthSearchPeriod=0
@@ -425,7 +425,7 @@ function checkpoint1()
         NrObs=AquaCrop.undef_int
     )
 
-    perennial_period = AquaCrop.RepPerennialPeriod( 
+    perennial_period = AquaCrop.RepPerennialPeriod(
         GenerateOnset=AquaCrop.undef_bool,
         OnsetCriterion=AquaCrop.undef_symbol,
         OnsetFirstDay=AquaCrop.undef_int,
@@ -533,27 +533,27 @@ function checkpoint1()
     AquaCrop.setparameter!(float_parameters, :scor_at2, AquaCrop.undef_double)
     AquaCrop.setparameter!(float_parameters, :stressleaf, AquaCrop.undef_double)
     AquaCrop.setparameter!(float_parameters, :stresssenescence, AquaCrop.undef_double)
-    AquaCrop.setparameter!(float_parameters, :tact, 0.0) 
-    AquaCrop.setparameter!(float_parameters, :tpot, 0.0) 
-    AquaCrop.setparameter!(float_parameters, :bin, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :bout, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :surf0, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :ecdrain, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :eact, 0.0) 
-    AquaCrop.setparameter!(float_parameters, :epot, 0.0) 
-    AquaCrop.setparameter!(float_parameters, :tactweedinfested, 0.0) 
-    AquaCrop.setparameter!(float_parameters, :saltinfiltr, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :ccitopearlysen, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :weedrci, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :cciactualweedinfested, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(float_parameters, :zeval, AquaCrop.undef_double) 
+    AquaCrop.setparameter!(float_parameters, :tact, 0.0)
+    AquaCrop.setparameter!(float_parameters, :tpot, 0.0)
+    AquaCrop.setparameter!(float_parameters, :bin, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :bout, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :surf0, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :ecdrain, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :eact, 0.0)
+    AquaCrop.setparameter!(float_parameters, :epot, 0.0)
+    AquaCrop.setparameter!(float_parameters, :tactweedinfested, 0.0)
+    AquaCrop.setparameter!(float_parameters, :saltinfiltr, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :ccitopearlysen, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :weedrci, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :cciactualweedinfested, AquaCrop.undef_double)
+    AquaCrop.setparameter!(float_parameters, :zeval, AquaCrop.undef_double)
 
     symbol_parameters = AquaCrop.ParametersContainer(Symbol)
     AquaCrop.setparameter!(symbol_parameters, :irrimode, :NoIrri) # 0
     AquaCrop.setparameter!(symbol_parameters, :irrimethod, :MSprinkler) # 4
     AquaCrop.setparameter!(symbol_parameters, :timemode, :AllRAW) # 2
     AquaCrop.setparameter!(symbol_parameters, :depthmode, :ToFC) # 0
-    AquaCrop.setparameter!(symbol_parameters, :theprojecttype, AquaCrop.undef_symbol) 
+    AquaCrop.setparameter!(symbol_parameters, :theprojecttype, AquaCrop.undef_symbol)
 
     integer_parameters = AquaCrop.ParametersContainer(Int)
     AquaCrop.setparameter!(integer_parameters, :iniperctaw, 50)
@@ -574,7 +574,7 @@ function checkpoint1()
     AquaCrop.setparameter!(integer_parameters, :daylastcut, AquaCrop.undef_int)
     AquaCrop.setparameter!(integer_parameters, :stagecode, AquaCrop.undef_int)
     AquaCrop.setparameter!(integer_parameters, :previoussdaynr, AquaCrop.undef_int)
-    AquaCrop.setparameter!(integer_parameters, :outputaggregate, AquaCrop.undef_int) 
+    AquaCrop.setparameter!(integer_parameters, :outputaggregate, AquaCrop.undef_int)
     AquaCrop.setparameter!(integer_parameters, :tnxreferenceyear, 2000)
     AquaCrop.setparameter!(integer_parameters, :last_irri_dap, AquaCrop.undef_int)
 
@@ -655,7 +655,7 @@ function checkpoint1()
          :clim_record => clim_record,
          :temperature_record => temperature_record,
          :perennial_period => perennial_period,
-         :crop_file_set => crop_file_set, 
+         :crop_file_set => crop_file_set,
          :gwtable => gwtable,
          :stresstot => stresstot,
          :irri_info_record1 => irri_info_record1,
@@ -678,7 +678,7 @@ function checkpoint1()
 end
 
 function checkpoint2()
-    gvars = checkpoint1()    
+    gvars = checkpoint1()
 
     gvars[:simulation].MultipleRun = true
     gvars[:simulation].NrRuns = 3
@@ -686,8 +686,8 @@ function checkpoint2()
     gvars[:simulation].MultipleRunConstZrx = 3
     # OJO this is incorrect in fortran code, they forget to set the temperature in line startuni.f90:864
     # it should be: call SetSimulParam_Tmin(Tmin_temp)  corrected in v7.2
-    # gvars[:simulparam].Tmin = 0 
-    
+    # gvars[:simulparam].Tmin = 0
+
     AquaCrop.setparameter!(gvars[:integer_parameters], :outputaggregate, 0)
 
     AquaCrop.setparameter!(gvars[:symbol_parameters], :theprojecttype, :typeprm)
@@ -698,25 +698,25 @@ function checkpoint2()
     AquaCrop.setparameter!(gvars[:bool_parameters], :out4Salt, true)
     AquaCrop.setparameter!(gvars[:bool_parameters], :out5CompWC, true)
     AquaCrop.setparameter!(gvars[:bool_parameters], :out6CompEC, true)
-    AquaCrop.setparameter!(gvars[:bool_parameters], :out7Clim, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :out7Clim, true)
     AquaCrop.setparameter!(gvars[:bool_parameters], :outdaily, true)
     AquaCrop.setparameter!(gvars[:bool_parameters], :part1Mult, true)
     AquaCrop.setparameter!(gvars[:bool_parameters], :part2Eval, true)
     AquaCrop.setparameter!(gvars[:bool_parameters], :part2Eval, true)
 
-    AquaCrop.setparameter!(gvars[:string_parameters], :man_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :man_file,
             joinpath(pwd(), "testcase/DATA/Ottawa.MAN"))
-    AquaCrop.setparameter!(gvars[:string_parameters], :observations_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :observations_file,
             joinpath(pwd(), "testcase/OBS/Ottawa.OBS"))
-    AquaCrop.setparameter!(gvars[:string_parameters], :rain_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :rain_file,
             joinpath(pwd(), "testcase/DATA/Ottawa.PLU"))
-    AquaCrop.setparameter!(gvars[:string_parameters], :temperature_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :temperature_file,
             joinpath(pwd(), "testcase/DATA/Ottawa.Tnx"))
-    AquaCrop.setparameter!(gvars[:string_parameters], :eto_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :eto_file,
             joinpath(pwd(), "testcase/DATA/Ottawa.ETo"))
-    AquaCrop.setparameter!(gvars[:string_parameters], :prof_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :prof_file,
             joinpath(pwd(), "testcase/DATA/Ottawa.SOL"))
-    AquaCrop.setparameter!(gvars[:string_parameters], :CO2_file, 
+    AquaCrop.setparameter!(gvars[:string_parameters], :CO2_file,
             joinpath(pwd(), "testcase/SIMUL/MaunaLoa.CO2"))
     AquaCrop.setparameter!(gvars[:string_parameters], :clim_file,  "EToRainTempFile")
     AquaCrop.setparameter!(gvars[:string_parameters], :swcini_file,  "(None)")
@@ -899,7 +899,7 @@ function checkpoint2()
         )
     ]
 
-    return gvars 
+    return gvars
 end
 
 function checkpoint3()
@@ -1133,8 +1133,8 @@ function checkpoint3()
         ResponseECsw=100,
         SmaxTopQuarter=0.02,
         SmaxBotQuarter=0.01,
-        SmaxTop=0.02166666666666, 
-        SmaxBot=0.008333333333, 
+        SmaxTop=0.02166666666666,
+        SmaxBot=0.008333333333,
         KcTop=1.15,
         KcDecline=0.05,
         CCEffectEvapLate=60,
@@ -1207,7 +1207,7 @@ function checkpoint3()
     )
     gvars[:crop] = crop
 
-    
+
     gvars[:management].FertilityStress = 50
     gvars[:management].WeedShape = 100
     gvars[:management].Cuttings.Considered = true
@@ -1286,7 +1286,7 @@ function checkpoint3()
     gvars[:temperature_record] = temperature_record
 
 
-    perennial_period = AquaCrop.RepPerennialPeriod( 
+    perennial_period = AquaCrop.RepPerennialPeriod(
         GenerateOnset=true,
         OnsetCriterion=:GDDPeriod, #2
         OnsetFirstDay=1,
@@ -1323,9 +1323,9 @@ function checkpoint3()
     gvars[:crop_file_set] = crop_file_set
 
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :temperature_file_exists, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :eto_file_exists, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :rain_file_exists, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :temperature_file_exists, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :eto_file_exists, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :rain_file_exists, true)
 
 
     Tmin = Float64[]
@@ -1370,7 +1370,7 @@ function checkpoint3()
     AquaCrop.setparameter!(gvars[:array_parameters], :Rain, Rain)
 
     AquaCrop.setparameter!(gvars[:integer_parameters], :tnxreferenceyear, 2015)
-    
+
     return gvars
 end
 
@@ -1468,53 +1468,53 @@ function checkpoint5()
     AquaCrop.setparameter!(gvars[:float_parameters], :rain, 0.1)
     AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 10.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 22.7)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 11.35) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :dayfraction, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayfraction, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 0.3) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :cgcref, 0.14184615384615384) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddcgcref, 0.012) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_bef, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at1, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at2, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi_adj, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :scor_at1, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :scor_at2, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :stresssenescence, AquaCrop.undef_double) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :zeval, 1.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 11.35)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :dayfraction, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayfraction, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 0.3)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :cgcref, 0.14184615384615384)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddcgcref, 0.012)
+    AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_bef, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at1, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at2, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi_adj, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :scor_at1, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :scor_at2, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :stresssenescence, AquaCrop.undef_double)
+    AquaCrop.setparameter!(gvars[:float_parameters], :zeval, 1.0)
 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 1) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :tadj, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :gddtadj, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 1) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :last_irri_dap, 0) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 1)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :tadj, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :gddtadj, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 1)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :last_irri_dap, 0)
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :nomorecrop, false) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :nomorecrop, false)
 
     gvars[:simulation].SumGDD = 11.35
     gvars[:simulation].SumGDDfromDay1 = 11.35
-    gvars[:simulation].Storage.Btotal = 0 
-    gvars[:simulation].Storage.Season = 1 
-    gvars[:simulation].Storage.CropString = "DEFAULT.CRO" 
-    gvars[:simulation].SCor = 1 
+    gvars[:simulation].Storage.Btotal = 0
+    gvars[:simulation].Storage.Season = 1
+    gvars[:simulation].Storage.CropString = "DEFAULT.CRO"
+    gvars[:simulation].SCor = 1
     gvars[:simulation].HIfinal = 100
 
     gvars[:crop].CCxAdjusted = 0.95
@@ -1525,12 +1525,12 @@ function checkpoint5()
 
     gvars[:cut_info_record1].NoMoreInfo = false
     gvars[:cut_info_record1].FromDay = 194
-    gvars[:cut_info_record1].MassInfo = 0 
-    gvars[:cut_info_record1].IntervalInfo = 0 
+    gvars[:cut_info_record1].MassInfo = 0
+    gvars[:cut_info_record1].IntervalInfo = 0
 
     gvars[:cut_info_record2].NoMoreInfo = false
-    gvars[:cut_info_record2].MassInfo = 0 
-    gvars[:cut_info_record2].IntervalInfo = 0 
+    gvars[:cut_info_record2].MassInfo = 0
+    gvars[:cut_info_record2].IntervalInfo = 0
 
     gvars[:root_zone_salt].KsSalt = 1
     gvars[:root_zone_salt].ECe = 0
@@ -1548,7 +1548,7 @@ function checkpoint5()
             push!(Man,  man)
         end
     end
-    popfirst!(Man) # done in open_harvest_info -> get_next_harvest 
+    popfirst!(Man) # done in open_harvest_info -> get_next_harvest
     AquaCrop.setparameter!(gvars[:array_parameters], :Man, Man)
 
     #Obs
@@ -1576,7 +1576,7 @@ function checkpoint5()
         for line in eachline(file)
             splitedline = split(line)
             daynreval = parse(Int, popfirst!(splitedline))
-            daynreval += daynr1evaleval - 1  
+            daynreval += daynr1evaleval - 1
             if daynreval >= gvars[:simulation].FromDayNr
                 push!(DaynrEval, daynreval)
                 push!(CCmeanEval, parse(Float64, popfirst!(splitedline)))
@@ -1617,7 +1617,7 @@ function checkpoint6()
     AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surf0, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecdrain, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :drain, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :drain, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :runoff, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :tact, 0.40011810102533346)
     AquaCrop.setparameter!(gvars[:float_parameters], :infiltrated, 0.1)
@@ -1629,42 +1629,42 @@ function checkpoint6()
     AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double)
     AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.40011810102533346)
     AquaCrop.setparameter!(gvars[:float_parameters], :epot, 3.9041363452133968)
-    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 3.2087533516688618) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 3.2087533516688618)
     AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.053958919412640277) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.053958919412640277)
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.053958919412640277) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.40011810102533346) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.053958919412640277)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.40011810102533346)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 11.35)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 3.9)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 11.35)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 11.35)
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 0.10259438487829063) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 0.10259438487829063)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 68.082929449446098)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 10.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 22.7) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 11.35) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 0.3) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 10.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 22.7)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 11.35)
+    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 0.3)
 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 1) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 2) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 2) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41415) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 50) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 50) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 1)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 2)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 2)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41415)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 50)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 50)
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true)
 
     gvars[:crop].DaysToFullCanopySF = 39
     gvars[:crop].GDDaysToFullCanopySF = 461
@@ -1674,7 +1674,7 @@ function checkpoint6()
     gvars[:crop].CCoAdjusted = 0.05
     gvars[:crop].CCxWithered = 0.053958919412640277
     gvars[:crop].pActStom = 0.6291613445939892
-    
+
     gvars[:simulation].IrriECw = 0
     gvars[:simulation].EffectStress.RedCGC = 0
     gvars[:simulation].EffectStress.RedCCX = 0
@@ -1685,45 +1685,45 @@ function checkpoint6()
     gvars[:simulation].SWCtopSoilConsidered = false
     gvars[:simulation].DelayedDays = 0
     gvars[:simulation].SumGDD = 11.35
-    gvars[:simulation].SumGDDfromDay1 = 11.35 
+    gvars[:simulation].SumGDDfromDay1 = 11.35
     gvars[:simulation].Germinate = true
-    gvars[:simulation].ProtectedSeedling = true 
+    gvars[:simulation].ProtectedSeedling = true
     gvars[:simulation].EvapLimitON = false
     gvars[:simulation].SumEToStress = 0
     gvars[:simulation].EvapZ = 0.15
     gvars[:simulation].EvapStartStg2 = 22
     gvars[:simulation].DayAnaero = 0
     gvars[:simulation].HIfinal = 100
-    gvars[:simulation].Storage.Btotal = 0.0 
-    
-    
+    gvars[:simulation].Storage.Btotal = 0.0
+
+
     gvars[:soil_layers][1].WaterContent = 990.07975803387228
 
 
     gvars[:compartments][1].Theta = 0.25491128599592039
-    gvars[:compartments][1].Fluxout = 0 
+    gvars[:compartments][1].Fluxout = 0
     gvars[:compartments][1].Smax = 0.019444444411330752
-    gvars[:compartments][1].WFactor = 1 
-    gvars[:compartments][2].Fluxout = 0 
-    gvars[:compartments][2].Smax =  0.013888888772990968 
-    gvars[:compartments][2].WFactor = 1 
-    gvars[:compartments][3].Fluxout = 0 
+    gvars[:compartments][1].WFactor = 1
+    gvars[:compartments][2].Fluxout = 0
+    gvars[:compartments][2].Smax =  0.013888888772990968
+    gvars[:compartments][2].WFactor = 1
+    gvars[:compartments][3].Fluxout = 0
     gvars[:compartments][3].Smax = 0.0094444443616602154
     gvars[:compartments][3].WFactor = 0.33333330353101132
     for i in 4:length(gvars[:compartments])
-        gvars[:compartments][i].Fluxout = 0 
+        gvars[:compartments][i].Fluxout = 0
         gvars[:compartments][i].Smax = 0
     end
 
 
     gvars[:total_water_content].BeginDay = 870.00001296401024
     gvars[:total_water_content].EndDay = 866.49114039441338
-    gvars[:total_water_content].ErrorDay = 0 
+    gvars[:total_water_content].ErrorDay = 0
 
 
-    gvars[:total_salt_content].BeginDay = 0 
-    gvars[:total_salt_content].EndDay = 0 
-    gvars[:total_salt_content].ErrorDay = 0 
+    gvars[:total_salt_content].BeginDay = 0
+    gvars[:total_salt_content].EndDay = 0
+    gvars[:total_salt_content].ErrorDay = 0
 
 
     gvars[:stresstot].NrD = 1
@@ -1731,7 +1731,7 @@ function checkpoint6()
 
     gvars[:sumwabal].Epot = 3.9041363452133968
     gvars[:sumwabal].Tpot = 0.40011810102533346
-    gvars[:sumwabal].Rain = 0.10000000000000001 
+    gvars[:sumwabal].Rain = 0.10000000000000001
     gvars[:sumwabal].Infiltrated = 0.10000000000000001
     gvars[:sumwabal].Eact = 3.2087533516688618
     gvars[:sumwabal].Tact = 0.40011810102533346
@@ -1741,7 +1741,7 @@ function checkpoint6()
     gvars[:sumwabal].BiomassUnlim = 0.01650675010092589
     gvars[:sumwabal].BiomassTot = 0.01650675010092589
 
-    
+
     gvars[:root_zone_wc].Actual = 83.491127430403097
     gvars[:root_zone_wc].FC = 87
     gvars[:root_zone_wc].WP = 39
@@ -1752,7 +1752,7 @@ function checkpoint6()
     gvars[:root_zone_wc].ZtopAct = 25.491128599592042
     gvars[:root_zone_wc].ZtopFC = 29
     gvars[:root_zone_wc].ZtopWP = 13
-    gvars[:root_zone_wc].ZtopThresh = 18.933418486496173 
+    gvars[:root_zone_wc].ZtopThresh = 18.933418486496173
 
 
     gvars[:plotvarcrop].PotVal = 5.6798862539621338
@@ -1773,122 +1773,122 @@ function checkpoint7()
     AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 0.95924771352550575)
     AquaCrop.setparameter!(gvars[:float_parameters], :bin, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bout, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :stresssenescence, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surf0, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecdrain, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :drain, 1.4609149173767255)
     AquaCrop.setparameter!(gvars[:float_parameters], :runoff, 1.1834135711751885)
-    AquaCrop.setparameter!(gvars[:float_parameters], :tact, 1.2407790447171203) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :infiltrated, 16.216586428824812) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tact, 1.2407790447171203)
+    AquaCrop.setparameter!(gvars[:float_parameters], :infiltrated, 16.216586428824812)
     AquaCrop.setparameter!(gvars[:float_parameters], :crwater, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :crsalt, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.42414769943608926) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.42414769943608926) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.42414769943608926)
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.42414769943608926)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double) #0
     AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 1.2407790447171203)
-    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.8934244530339831) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.8934244530339831) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.8934244530339831)
+    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.8934244530339831)
     AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.76087529682528598) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.76087529682528598)
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.42414769943608926) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 1.2407790447171203) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 269.35000000000002) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.42414769943608926)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 1.2407790447171203)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 269.35000000000002)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 77.199999999999989)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 269.35000000000002)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 269.35000000000002)
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 7.7977039579173981) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 7.7977039579173981)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 68.082929449446098)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 15.1) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 21.7) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 13.4) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 0.95924771352550575) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 15.1)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 21.7)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 13.4)
+    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 0.95924771352550575)
 
     AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int)  #-9
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 24) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 25) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 2) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41438) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 50) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 50) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 24)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 25)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 2)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41438)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 50)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 50)
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true)
 
-    gvars[:crop].DaysToFullCanopySF = 47 
-    gvars[:crop].GDDaysToFullCanopySF = 590 
+    gvars[:crop].DaysToFullCanopySF = 47
+    gvars[:crop].GDDaysToFullCanopySF = 590
     gvars[:crop].pLeafAct = 0.26618999732563697
-    gvars[:crop].pSenAct = 0.77045701378430731 
-    gvars[:crop].CCxAdjusted = 0.42414769943608926 
+    gvars[:crop].pSenAct = 0.77045701378430731
+    gvars[:crop].CCxAdjusted = 0.42414769943608926
     gvars[:crop].CCoAdjusted = 0.05
-    gvars[:crop].CCxWithered = 0.42414769943608926 
-    gvars[:crop].pActStom = 0.6821819711285152 
-    
+    gvars[:crop].CCxWithered = 0.42414769943608926
+    gvars[:crop].pActStom = 0.6821819711285152
+
     gvars[:simulation].IrriECw = 0
     gvars[:simulation].EffectStress.RedCGC = 24
     gvars[:simulation].EffectStress.RedCCX = 40
     gvars[:simulation].EffectStress.RedWP = 52
-    gvars[:simulation].EffectStress.CDecline = 0.04188660705779268 
+    gvars[:simulation].EffectStress.CDecline = 0.04188660705779268
     gvars[:simulation].EffectStress.RedKsSto = 0
     gvars[:simulation].SCor = 1
-    gvars[:simulation].SWCtopSoilConsidered = true 
+    gvars[:simulation].SWCtopSoilConsidered = true
     gvars[:simulation].DelayedDays = 0
     gvars[:simulation].SumGDD = 269.35000000000002
-    gvars[:simulation].SumGDDfromDay1 = 269.35000000000002 
+    gvars[:simulation].SumGDDfromDay1 = 269.35000000000002
     gvars[:simulation].Germinate = true
-    gvars[:simulation].ProtectedSeedling = false 
+    gvars[:simulation].ProtectedSeedling = false
     gvars[:simulation].EvapLimitON = false
     gvars[:simulation].SumEToStress = 0
     gvars[:simulation].EvapZ = 0.15
     gvars[:simulation].EvapStartStg2 = AquaCrop.undef_int
     gvars[:simulation].DayAnaero = 0
     gvars[:simulation].HIfinal = 100
-    gvars[:simulation].Storage.Btotal = 0.0 
+    gvars[:simulation].Storage.Btotal = 0.0
     gvars[:simulation].EvapWCsurf = 6.1065755469660168
 
-    
-    
+
+
     gvars[:soil_layers][1].WaterContent = 1113.496785944229
 
 
 
     gvars[:compartments][1].Theta = 0.43142746809393107
-    gvars[:compartments][1].Fluxout = 13.522763328844601 
+    gvars[:compartments][1].Fluxout = 13.522763328844601
     gvars[:compartments][1].Smax = 0.020971677596376796
-    gvars[:compartments][1].WFactor = 1 
-    gvars[:compartments][1].DayAnaero = 1 
+    gvars[:compartments][1].WFactor = 1
+    gvars[:compartments][1].DayAnaero = 1
 
     gvars[:compartments][2].Theta = 0.29127477265228668
     gvars[:compartments][2].Fluxout = 2.008132421942721
-    gvars[:compartments][2].Smax =  0.019234204920652122 
-    gvars[:compartments][2].WFactor = 1 
+    gvars[:compartments][2].Smax =  0.019234204920652122
+    gvars[:compartments][2].WFactor = 1
 
     gvars[:compartments][3].Theta = 0.29100878230301236
     gvars[:compartments][3].Fluxout = 1.8568150742360574
-    gvars[:compartments][3].Smax =  0.017149237709782515 
-    gvars[:compartments][3].WFactor = 1 
-    
+    gvars[:compartments][3].Smax =  0.017149237709782515
+    gvars[:compartments][3].WFactor = 1
+
     gvars[:compartments][4].Theta = 0.29045546555995505
     gvars[:compartments][4].Fluxout = 1.76572196088764490
     gvars[:compartments][4].Smax = 0.014716775963767973
-    gvars[:compartments][4].WFactor = 1 
+    gvars[:compartments][4].WFactor = 1
 
     gvars[:compartments][5].Theta = 0.29038137404394987
     gvars[:compartments][5].Fluxout = 1.6894471509610822
     gvars[:compartments][5].Smax = 0.011936819682608495
-    gvars[:compartments][5].WFactor = 1 
+    gvars[:compartments][5].WFactor = 1
 
     gvars[:compartments][6].Theta = 0.29019032103826997
     gvars[:compartments][6].Fluxout = 1.6418668906845735
@@ -1906,15 +1906,15 @@ function checkpoint7()
     gvars[:compartments][9].Theta = 0.2901074057246778
     gvars[:compartments][9].Fluxout = 1.5312233637847052
     gvars[:compartments][9].Smax = 0
-    
+
     gvars[:compartments][10].Theta = 0.29007184096573579
     gvars[:compartments][10].Fluxout = 1.5060783608312696
     gvars[:compartments][10].Smax = 0
-    
+
     gvars[:compartments][11].Theta = 0.29007101761758292
     gvars[:compartments][11].Fluxout = 1.4812215366415957
     gvars[:compartments][11].Smax = 0
-    
+
     gvars[:compartments][12].Theta = 0.29005076520285616
     gvars[:compartments][12].Fluxout = 1.4609149173767255
     gvars[:compartments][12].Smax = 0
@@ -1923,17 +1923,17 @@ function checkpoint7()
 
     gvars[:total_water_content].BeginDay = 872.25972511227815
     gvars[:total_water_content].EndDay = 884.88119312945332
-    gvars[:total_water_content].ErrorDay = 2.2737367544323206e-13 
+    gvars[:total_water_content].ErrorDay = 2.2737367544323206e-13
 
 
-    gvars[:total_salt_content].BeginDay = 0 
-    gvars[:total_salt_content].EndDay = 0 
-    gvars[:total_salt_content].ErrorDay = 0 
+    gvars[:total_salt_content].BeginDay = 0
+    gvars[:total_salt_content].EndDay = 0
+    gvars[:total_salt_content].ErrorDay = 0
 
 
     gvars[:stresstot].Temp = 0.24549857357286284
     gvars[:stresstot].Exp = 0.018299504815995814
-    gvars[:stresstot].Sto = -9.2518585385429718e-16 
+    gvars[:stresstot].Sto = -9.2518585385429718e-16
     gvars[:stresstot].NrD = 24
 
 
@@ -1953,9 +1953,9 @@ function checkpoint7()
     gvars[:sumwabal].BiomassUnlim = 1.7945119034352373
     gvars[:sumwabal].BiomassTot = 1.2514531564505482
 
-    
-    gvars[:root_zone_wc].Actual = 292.86479304216704 
-    gvars[:root_zone_wc].FC = 278.18183692239666 
+
+    gvars[:root_zone_wc].Actual = 292.86479304216704
+    gvars[:root_zone_wc].FC = 278.18183692239666
     gvars[:root_zone_wc].WP = 124.70220275831575
     gvars[:root_zone_wc].SAT = 441.25394822173263
     gvars[:root_zone_wc].Leaf = 237.32709351472025
@@ -1968,9 +1968,9 @@ function checkpoint7()
 
 
     gvars[:plotvarcrop].PotVal = 80.092136507924835
-    gvars[:plotvarcrop].ActVal = 44.647126256430454 
+    gvars[:plotvarcrop].ActVal = 44.647126256430454
 
-    return outputs, gvars 
+    return outputs, gvars
 end
 
 function checkpoint8()
@@ -1985,166 +1985,166 @@ function checkpoint8()
     AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 2.6103245071754047)
     AquaCrop.setparameter!(gvars[:float_parameters], :bin, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bout, 0.022404426367023146)
-    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :stresssenescence, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surf0, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecdrain, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :drain, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :runoff, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :drain, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :runoff, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :tact,  0.84110157853297807)
-    AquaCrop.setparameter!(gvars[:float_parameters], :infiltrated, 3.7) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :infiltrated, 3.7)
     AquaCrop.setparameter!(gvars[:float_parameters], :crwater, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :crsalt, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.50705716529127109) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.50705716529127109) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.50705716529127109)
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.50705716529127109)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double) #0
-    AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.84110157853297807) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.53262172860540868) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.53262172860540868) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.84110157853297807)
+    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.53262172860540868)
+    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.53262172860540868)
     AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos,  0.94999995068061738)
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.50705716529127109) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.84110157853297807) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.50705716529127109)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.84110157853297807)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd,  1532.6499999999992)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 380.5)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 183.74999999999997)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 1532.6499999999992) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 69.800542947909491) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 1532.6499999999992)
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 69.800542947909491)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 69.444588038435015)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 7.8685716221193092) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 7.8685716221193092)
     AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum,  7.7105201487764337)
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 5.1) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 15.9) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 5.5) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 5.1)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 15.9)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 5.5)
     AquaCrop.setparameter!(gvars[:float_parameters], :ziprev,  2.6103245071754047)
 
     AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int)  #-9
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 17) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 121) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 2) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 103) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 2) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41534) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 49) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 49) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 17)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 121)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 2)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 103)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 2)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41534)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 49)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 49)
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true)
 
-    gvars[:crop].DaysToFullCanopySF = 47 
-    gvars[:crop].GDDaysToFullCanopySF = 590 
-    gvars[:crop].pLeafAct = 0.28493031947493325 
-    gvars[:crop].pSenAct = 0.78182104826564724 
-    gvars[:crop].CCxAdjusted = 0.50705716529127109 
+    gvars[:crop].DaysToFullCanopySF = 47
+    gvars[:crop].GDDaysToFullCanopySF = 590
+    gvars[:crop].pLeafAct = 0.28493031947493325
+    gvars[:crop].pSenAct = 0.78182104826564724
+    gvars[:crop].CCxAdjusted = 0.50705716529127109
     gvars[:crop].CCoAdjusted = 0.05
-    gvars[:crop].CCxWithered = 0.50705716529127109 
-    gvars[:crop].pActStom = 0.69543712776214661 
-    
+    gvars[:crop].CCxWithered = 0.50705716529127109
+    gvars[:crop].pActStom = 0.69543712776214661
+
     gvars[:simulation].IrriECw = 0
     gvars[:simulation].EffectStress.RedCGC = 23
     gvars[:simulation].EffectStress.RedCCX = 39
     gvars[:simulation].EffectStress.RedWP = 51
-    gvars[:simulation].EffectStress.CDecline = 0.039228692992979708 
+    gvars[:simulation].EffectStress.CDecline = 0.039228692992979708
     gvars[:simulation].EffectStress.RedKsSto = 0
     gvars[:simulation].SCor = 1
-    gvars[:simulation].SWCtopSoilConsidered = true 
+    gvars[:simulation].SWCtopSoilConsidered = true
     gvars[:simulation].DelayedDays = 0
     gvars[:simulation].SumGDD = 1532.6499999999992
-    gvars[:simulation].SumGDDfromDay1 = 1532.6499999999992 
+    gvars[:simulation].SumGDDfromDay1 = 1532.6499999999992
     gvars[:simulation].Germinate = true
-    gvars[:simulation].ProtectedSeedling = false 
+    gvars[:simulation].ProtectedSeedling = false
     gvars[:simulation].EvapLimitON = false
     gvars[:simulation].SumEToStress = 0
     gvars[:simulation].EvapZ = 0.15
     gvars[:simulation].EvapStartStg2 = AquaCrop.undef_int
     gvars[:simulation].DayAnaero = 0
     gvars[:simulation].HIfinal = 100
-    gvars[:simulation].Storage.Btotal = 1.3884550744095494 
+    gvars[:simulation].Storage.Btotal = 1.3884550744095494
     gvars[:simulation].EvapWCsurf = 3.1673782713945915
 
- 
-    
+
+
     gvars[:soil_layers][1].WaterContent = 948.99281044484053
 
 
     gvars[:compartments][1].Theta = 0.28864042029259473
-    gvars[:compartments][1].Fluxout = 0 
+    gvars[:compartments][1].Fluxout = 0
     gvars[:compartments][1].Smax = 0.021411270575196734
-    gvars[:compartments][1].WFactor = 1 
+    gvars[:compartments][1].WFactor = 1
 
     gvars[:compartments][2].Theta = 0.28976976167910812
-    gvars[:compartments][2].Fluxout = 0 
-    gvars[:compartments][2].Smax =  0.020772780346521906 
-    gvars[:compartments][2].WFactor = 1 
+    gvars[:compartments][2].Fluxout = 0
+    gvars[:compartments][2].Smax =  0.020772780346521906
+    gvars[:compartments][2].WFactor = 1
 
     gvars[:compartments][3].Theta = 0.16871872321973436
-    gvars[:compartments][3].Fluxout = 0 
-    gvars[:compartments][3].Smax =  0.020006592072112112 
-    gvars[:compartments][3].WFactor = 1 
-    
+    gvars[:compartments][3].Fluxout = 0
+    gvars[:compartments][3].Smax =  0.020006592072112112
+    gvars[:compartments][3].WFactor = 1
+
     gvars[:compartments][4].Theta = 0.28363179629528518
     gvars[:compartments][4].Fluxout = 0
     gvars[:compartments][4].Smax = 0.01911270575196735
-    gvars[:compartments][4].WFactor = 1 
+    gvars[:compartments][4].WFactor = 1
 
     gvars[:compartments][5].Theta = 0.29
-    gvars[:compartments][5].Fluxout = 0 
+    gvars[:compartments][5].Fluxout = 0
     gvars[:compartments][5].Smax = 0.018091121386087622
-    gvars[:compartments][5].WFactor = 1 
+    gvars[:compartments][5].WFactor = 1
 
     gvars[:compartments][6].Theta = 0.29
-    gvars[:compartments][6].Fluxout = 0 
+    gvars[:compartments][6].Fluxout = 0
     gvars[:compartments][6].Smax = 0.01694183897447293
-    gvars[:compartments][6].WFactor = 1 
+    gvars[:compartments][6].WFactor = 1
 
     gvars[:compartments][7].Theta = 0.29
-    gvars[:compartments][7].Fluxout = 0 
+    gvars[:compartments][7].Fluxout = 0
     gvars[:compartments][7].Smax = 0.015664858517123272
-    gvars[:compartments][7].WFactor = 1 
+    gvars[:compartments][7].WFactor = 1
 
     gvars[:compartments][8].Theta = 0.29
-    gvars[:compartments][8].Fluxout = 0 
+    gvars[:compartments][8].Fluxout = 0
     gvars[:compartments][8].Smax = 0.014260180014038646
-    gvars[:compartments][8].WFactor = 1 
+    gvars[:compartments][8].WFactor = 1
 
     gvars[:compartments][9].Theta = 0.29
     gvars[:compartments][9].Fluxout = 0
     gvars[:compartments][9].Smax = 0.012727803465219057
-    gvars[:compartments][9].WFactor = 1 
-    
+    gvars[:compartments][9].WFactor = 1
+
     gvars[:compartments][10].Theta = 0.28999999999999998
     gvars[:compartments][10].Fluxout = 0
     gvars[:compartments][10].Smax = 0.011067728870664499
-    gvars[:compartments][10].WFactor = 1 
-    
+    gvars[:compartments][10].WFactor = 1
+
     gvars[:compartments][11].Theta = 0.28999999999999998
     gvars[:compartments][11].Fluxout = 0
     gvars[:compartments][11].Smax = 0.0092799562303749784
-    gvars[:compartments][11].WFactor = 1 
-    
+    gvars[:compartments][11].WFactor = 1
+
     gvars[:compartments][12].Theta = 0.28999999999999998
-    gvars[:compartments][12].Fluxout = 0 
+    gvars[:compartments][12].Fluxout = 0
     gvars[:compartments][12].Smax = 0.008359701621781776
     gvars[:compartments][12].WFactor = 0.025811170696347453
 
 
-    gvars[:total_water_content].BeginDay = 848.03741000168748 
+    gvars[:total_water_content].BeginDay = 848.03741000168748
     gvars[:total_water_content].EndDay = 850.36368669454907
-    gvars[:total_water_content].ErrorDay = 1.1368683772161603e-13 
+    gvars[:total_water_content].ErrorDay = 1.1368683772161603e-13
 
 
 
-    gvars[:total_salt_content].BeginDay = 0 
-    gvars[:total_salt_content].EndDay = 0 
-    gvars[:total_salt_content].ErrorDay = 0 
+    gvars[:total_salt_content].BeginDay = 0
+    gvars[:total_salt_content].EndDay = 0
+    gvars[:total_salt_content].ErrorDay = 0
 
 
 
@@ -2152,17 +2152,17 @@ function checkpoint8()
 
 
 
-    gvars[:transfer].Store = true 
+    gvars[:transfer].Store = true
 
 
 
-    gvars[:stresstot].Temp = 1.0034186854568179 
+    gvars[:stresstot].Temp = 1.0034186854568179
     gvars[:stresstot].Exp = 0.0057830594196914059
-    gvars[:stresstot].Sto = -9.2518585385429718e-16 
+    gvars[:stresstot].Sto = -9.2518585385429718e-16
     gvars[:stresstot].NrD = 120
 
 
-    
+
     gvars[:sumwabal].Epot = 176.93494744033052
     gvars[:sumwabal].Tpot = 248.97054516688019
     gvars[:sumwabal].Rain = 382.40000000000003
@@ -2179,7 +2179,7 @@ function checkpoint8()
     gvars[:sumwabal].BiomassUnlim = 17.258690484517839
     gvars[:sumwabal].BiomassTot = 8.4126510919056781
 
-    
+
     gvars[:root_zone_wc].Actual = 737.3577808114062
     gvars[:root_zone_wc].FC = 756.99410708086737
     gvars[:root_zone_wc].WP = 339.34218593280258
@@ -2190,11 +2190,11 @@ function checkpoint8()
     gvars[:root_zone_wc].ZtopAct = 28.864042029259476
     gvars[:root_zone_wc].ZtopFC = 29
     gvars[:root_zone_wc].ZtopWP = 13
-    gvars[:root_zone_wc].ZtopThresh = 17.873005955805652 
+    gvars[:root_zone_wc].ZtopThresh = 17.873005955805652
 
 
     gvars[:plotvarcrop].PotVal = 99.999994808486036
-    gvars[:plotvarcrop].ActVal = 53.374438451712749 
+    gvars[:plotvarcrop].ActVal = 53.374438451712749
 
     return outputs, gvars
 end
@@ -2234,36 +2234,36 @@ function checkpoint9()
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.58155317481723878)
     AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 1802.6) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 431.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 1802.6)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 431.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 453.7)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 1802.6)
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 75.700525474588275) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 75.700525474588275)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 74.891222394390709)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 7.8685716221193092) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 7.7105201487764337) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, -0.5) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 7.3) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 7.8685716221193092)
+    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 7.7105201487764337)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, -0.5)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 7.3)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 2.8849256144259785)
 
 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 61) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 165) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 2) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 103) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 0) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 61)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 165)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41413)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 2)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 103)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 0)
     AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41578)
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 45) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 45) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 45)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 45)
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true)
 
     gvars[:crop].DaysToFullCanopySF = 45
     gvars[:crop].GDDaysToFullCanopySF = 562
@@ -2273,7 +2273,7 @@ function checkpoint9()
     gvars[:crop].CCoAdjusted = 0.05
     gvars[:crop].CCxWithered = 0.58155317481723878
     gvars[:crop].pActStom = 0.71929640970268327
-    
+
     gvars[:simulation].IrriECw = 0
     gvars[:simulation].EffectStress.RedCGC = 20
     gvars[:simulation].EffectStress.RedCCX = 35
@@ -2298,7 +2298,7 @@ function checkpoint9()
 
     gvars[:soil_layers][1].WaterContent = 1009.1557018884808
 
-        
+
     gvars[:compartments][1].Theta = 0.28888071115790098
     gvars[:compartments][1].Fluxout = 0.55756742461396558
     gvars[:compartments][1].Smax = 0.021435246510529159
@@ -2310,7 +2310,7 @@ function checkpoint9()
     gvars[:compartments][2].Smax = 0.020856696120185387
     gvars[:compartments][2].WFactor = 0.22218498638893547
 
-    
+
     gvars[:compartments][3].Theta = 0.29019870962556377
     gvars[:compartments][3].Fluxout = 0.58388349617452984
     gvars[:compartments][3].Smax = 0.020162435651772861
@@ -2322,7 +2322,7 @@ function checkpoint9()
     gvars[:compartments][4].Smax = 0.01935246510529158
     gvars[:compartments][4].WFactor = 0
 
-    
+
     gvars[:compartments][5].Theta = 0.29008792636992675
     gvars[:compartments][5].Fluxout = 0.61943981207670773
     gvars[:compartments][5].Smax = 0.018426784480741545
@@ -2334,37 +2334,37 @@ function checkpoint9()
     gvars[:compartments][6].Smax = 0.017385393778122753
     gvars[:compartments][6].WFactor = 0
 
-    
+
     gvars[:compartments][7].Theta = 0.29005359230987582
     gvars[:compartments][7].Fluxout = 0.65684356925080101
     gvars[:compartments][7].Smax = 0.016228292997435209
     gvars[:compartments][7].WFactor = 0
 
-    
+
     gvars[:compartments][8].Theta = 0.29004457836760383
     gvars[:compartments][8].Fluxout = 0.67493117727808816
     gvars[:compartments][8].Smax = 0.014955482138678911
     gvars[:compartments][8].WFactor = 0
 
-    
+
     gvars[:compartments][9].Theta = 0.29004448362231922
     gvars[:compartments][9].Fluxout = 0.68816814440753449
     gvars[:compartments][9].Smax = 0.013566961201853855
     gvars[:compartments][9].WFactor = 0
 
-    
+
     gvars[:compartments][10].Theta = 0.2900320546496038
     gvars[:compartments][10].Fluxout = 0.70411781302047172
     gvars[:compartments][10].Smax = 0.012062730186960049
     gvars[:compartments][10].WFactor = 0
 
-    
+
     gvars[:compartments][11].Theta = 0.29003131002431454
     gvars[:compartments][11].Fluxout = 0.71671714275098364
     gvars[:compartments][11].Smax = 0.010442789093997488
     gvars[:compartments][11].WFactor = 0
 
-    
+
     gvars[:compartments][12].Theta = 0.29002446769251361
     gvars[:compartments][12].Fluxout = 0.73087658631881447
     gvars[:compartments][12].Smax = 0.0089830759404247694
@@ -2376,21 +2376,21 @@ function checkpoint9()
     gvars[:total_water_content].BeginDay = 870.977095826452
     gvars[:total_water_content].EndDay = 870.09922446179735
     gvars[:total_water_content].ErrorDay = -1.1368683772161603e-13
-    
+
 
     gvars[:total_salt_content].BeginDay = 0
     gvars[:total_salt_content].EndDay = 0
     gvars[:total_salt_content].ErrorDay = 0
 
-    
+
     gvars[:stresstot].Salt = 0
     gvars[:stresstot].Temp = 11.497152813109741
     gvars[:stresstot].Exp = 0.0043805036140225186
     gvars[:stresstot].Sto = -6.9414627017820649e-17
     gvars[:stresstot].Weed = 0
-    gvars[:stresstot].NrD = 164 
+    gvars[:stresstot].NrD = 164
 
-    
+
     gvars[:sumwabal].Epot = 194.93774816572909
     gvars[:sumwabal].Tpot = 276.36090846630663
     gvars[:sumwabal].Rain = 487.50000000000011
@@ -2400,7 +2400,7 @@ function checkpoint9()
     gvars[:sumwabal].Drain = 65.04942280327873
     gvars[:sumwabal].Eact = 142.5818905037425
     gvars[:sumwabal].Tact = 276.36090846630663
-    gvars[:sumwabal].TrW = 276.36090846630663 
+    gvars[:sumwabal].TrW = 276.36090846630663
     gvars[:sumwabal].ECropCycle = 142.5818905037425
     gvars[:sumwabal].CRwater = 0
     gvars[:sumwabal].Biomass = 9.1724462468553778
@@ -2410,8 +2410,8 @@ function checkpoint9()
     gvars[:sumwabal].BiomassTot = 9.1724462468553778
     gvars[:sumwabal].SaltIn = 0
     gvars[:sumwabal].SaltOut = 0
-    gvars[:sumwabal].CRsalt = 0 
- 
+    gvars[:sumwabal].CRsalt = 0
+
 
     gvars[:cut_info_record1].NoMoreInfo = false
     gvars[:cut_info_record1].FromDay = 536
@@ -2427,14 +2427,14 @@ function checkpoint9()
     gvars[:root_zone_wc].ZtopAct = 28.888071115790098
     gvars[:root_zone_wc].ZtopFC = 29
     gvars[:root_zone_wc].ZtopWP = 13
-    gvars[:root_zone_wc].ZtopThresh = 17.491257444757068 
+    gvars[:root_zone_wc].ZtopThresh = 17.491257444757068
 
 
     gvars[:transfer].Store = true
-    gvars[:transfer].Mobilize = false 
+    gvars[:transfer].Mobilize = false
 
     gvars[:plotvarcrop].PotVal = 99.999999796558043
-    gvars[:plotvarcrop].ActVal = 61.216123664972514 
+    gvars[:plotvarcrop].ActVal = 61.216123664972514
 
     return outputs, gvars
 end
@@ -2444,8 +2444,8 @@ function checkpoint10()
 
     AquaCrop.setparameter!(gvars[:float_parameters], :eto, 0.5)
     AquaCrop.setparameter!(gvars[:float_parameters], :rain, 0.4)
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, -0.2) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 4.5) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, -0.2)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 4.5)
     AquaCrop.setparameter!(gvars[:float_parameters], :irrigation, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0)
@@ -2455,67 +2455,67 @@ function checkpoint10()
     AquaCrop.setparameter!(gvars[:float_parameters], :crwater, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :crsalt, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :eciaqua, AquaCrop.undef_double) #undef_int
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :previoussumeto, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :previoussumgdd, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :previousbmob, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :previousbmob, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :previousbsto, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :co2i, 401.02) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :fracbiomasspotsf, 0.50413160021816306) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :co2i, 401.02)
+    AquaCrop.setparameter!(gvars[:float_parameters], :fracbiomasspotsf, 0.50413160021816306)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb0, 85.378783945055247)
-    AquaCrop.setparameter!(gvars[:float_parameters], :coeffb1, -0.55286978274556109) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :coeffb1, -0.55286978274556109)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb2, -0.002953450441497352)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb0salt, 0.78360738811204911)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb1salt, 0.33693757850594308)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb2salt, 0.0054227015016671491)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop, 177.07980969376374)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 89.271527827244896) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 89.271527827244896)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :fweednos, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccxcrop_weednosf_stress, 0.95) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :fweednos, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccxcrop_weednosf_stress, 0.95)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccxtotal, 0.94851562500000008)
     AquaCrop.setparameter!(gvars[:float_parameters], :cdctotal, 0.006)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddcdctotal, 0.006) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddcdctotal, 0.006)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccototal, 0.048023576462394767)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :dayfraction, 0.88079470198675491)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayfraction, 0.90017016449234255) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayfraction, 0.90017016449234255)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, AquaCrop.undef_double)
-    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :cgcref, 0.12572727272727272)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddcgcref, 0.012) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddcgcref, 0.012)
     AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_bef, AquaCrop.undef_double)
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at1, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at2, 1.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at1, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at2, 1.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at, 1.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, AquaCrop.undef_double)
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi_adj, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi_adj, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :scor_at1, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :scor_at2, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, AquaCrop.undef_double)
     AquaCrop.setparameter!(gvars[:float_parameters], :stresssenescence, AquaCrop.undef_double)
-    AquaCrop.setparameter!(gvars[:float_parameters], :tact, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tact, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bin, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bout, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surf0, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecdrain, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.54699252493568706) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.55000000000000004) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.54699252493568706)
+    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.55000000000000004)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double)
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.58155317481723878) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.58155317481723878)
 
 
     AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 0)
@@ -2532,27 +2532,27 @@ function checkpoint10()
 
     gvars[:crop].GDDaysToHarvest = 2048
     gvars[:crop].GDDaysToSenescence = 2048
-    gvars[:crop].GDDaysToFullCanopySF = 554 
-    gvars[:crop].GDDaysToCCini = 171 
-    gvars[:crop].DaysToMaxRooting = 149 
-    gvars[:crop].DaysToHarvest = 177 
-    gvars[:crop].DaysToSenescence = 177 
-    gvars[:crop].DaysToFullCanopySF = 54 
-    gvars[:crop].DaysToFullCanopy = 44 
-    gvars[:crop].DaysToGermination = 2 
-    gvars[:crop].DaysToCCini = 16 
+    gvars[:crop].GDDaysToFullCanopySF = 554
+    gvars[:crop].GDDaysToCCini = 171
+    gvars[:crop].DaysToMaxRooting = 149
+    gvars[:crop].DaysToHarvest = 177
+    gvars[:crop].DaysToSenescence = 177
+    gvars[:crop].DaysToFullCanopySF = 54
+    gvars[:crop].DaysToFullCanopy = 44
+    gvars[:crop].DaysToGermination = 2
+    gvars[:crop].DaysToCCini = 16
     gvars[:crop].CCxAdjusted = 0.94851562500000008
     gvars[:crop].CCxWithered = 0
     gvars[:crop].CCoAdjusted = 0.048023576462394767
-    gvars[:crop].CDC = 0.006 
-    gvars[:crop].CGC = 0.12572727272727272 
-    gvars[:crop].RootMin = 3 
-    gvars[:crop].Length = [0, 26, 151, 0] 
+    gvars[:crop].CDC = 0.006
+    gvars[:crop].CGC = 0.12572727272727272
+    gvars[:crop].RootMin = 3
+    gvars[:crop].Length = [0, 26, 151, 0]
     gvars[:crop].Day1 = 41759
     gvars[:crop].DayN = 41935
-    gvars[:crop].pActStom = 0.6 
-    gvars[:crop].pLeafAct = 0.15 
-    gvars[:crop].pSenAct = 0.7 
+    gvars[:crop].pActStom = 0.6
+    gvars[:crop].pLeafAct = 0.15
+    gvars[:crop].pSenAct = 0.7
     gvars[:crop].Planting = :Regrowth
 
     gvars[:simulation].Storage.Btotal = 0.0
@@ -2568,22 +2568,22 @@ function checkpoint10()
     gvars[:simulation].ToDayNr = 41935
     gvars[:simulation].FromDayNr = 41578
 
-    gvars[:stresstot].Salt = 0 
-    gvars[:stresstot].Temp = 0 
-    gvars[:stresstot].Exp = 0 
-    gvars[:stresstot].Sto = 0 
-    gvars[:stresstot].Weed = 0 
-    gvars[:stresstot].NrD = AquaCrop.undef_int 
+    gvars[:stresstot].Salt = 0
+    gvars[:stresstot].Temp = 0
+    gvars[:stresstot].Exp = 0
+    gvars[:stresstot].Sto = 0
+    gvars[:stresstot].Weed = 0
+    gvars[:stresstot].NrD = AquaCrop.undef_int
 
     gvars[:sumwabal] = AquaCrop.RepSum()
 
     gvars[:transfer].Store = false
-    gvars[:transfer].Mobilize = true 
+    gvars[:transfer].Mobilize = true
     gvars[:transfer].ToMobilize = 0.2803701573967029
     gvars[:transfer].Bmobilized = 0
 
     gvars[:cut_info_record1].NoMoreInfo = false
-    gvars[:cut_info_record1].FromDay = 536 
+    gvars[:cut_info_record1].FromDay = 536
 
 
     outputs[:tcropsim] = Dict(
@@ -2642,7 +2642,7 @@ function checkpoint11()
     AquaCrop.setparameter!(gvars[:float_parameters], :rain, 3.6)
     AquaCrop.setparameter!(gvars[:float_parameters], :eciaqua, AquaCrop.undef_double)
     AquaCrop.setparameter!(gvars[:float_parameters], :irrigation, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 3.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 3.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bin, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bout, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, -33.0)
@@ -2659,7 +2659,7 @@ function checkpoint11()
     AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.55094167146255202)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.55094167146255202)
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double)
     AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.20179350918759695)
     AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.20179350918759695)
@@ -2669,43 +2669,43 @@ function checkpoint11()
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.55094167146255202)
     AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 2118.5999999999999) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 617.60000000000002) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 2118.5999999999999)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 617.60000000000002)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 495.19999999999987)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 2048.0500000000002)
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 94.536484974292236) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 94.536484974292236)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 93.852299137694786)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 10.761924694614526) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 10.761924694614528) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 0.5) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 8.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 10.761924694614526)
+    AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 10.761924694614528)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, 0.5)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 8.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 3.0)
 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 55) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 178) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41577) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 3) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 122) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 0) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :ziaqua, AquaCrop.undef_int)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daysubmerged, 0)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :suminterval, 55)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :irri_interval, 178)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previoussdaynr, 41577)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :nrcut, 3)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 122)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stagecode, 0)
     AquaCrop.setparameter!(gvars[:integer_parameters], :daynri, 41936)
-    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 47) 
-    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 47) 
+    AquaCrop.setparameter!(gvars[:integer_parameters], :stress_sf_adj_new, 47)
+    AquaCrop.setparameter!(gvars[:integer_parameters], :previous_stress_level, 47)
 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true) 
-    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true) 
+    AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :evapo_entire_soil_surface, true)
+    AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true)
 
     gvars[:crop].DaysToFullCanopySF = 52
     gvars[:crop].GDDaysToFullCanopySF = 524
     gvars[:crop].pLeafAct = 0.31491483491380734
     gvars[:crop].pSenAct = 0.80000350343579107
-    gvars[:crop].CCxAdjusted = 0.55095017048162265 
+    gvars[:crop].CCxAdjusted = 0.55095017048162265
     gvars[:crop].CCoAdjusted = 0.048023576462394767
-    gvars[:crop].CCxWithered = 0.55095017048162265 
+    gvars[:crop].CCxWithered = 0.55095017048162265
     gvars[:crop].pActStom = 0.71664537837595699
 
 
@@ -2716,7 +2716,7 @@ function checkpoint11()
     gvars[:simulation].EffectStress.CDecline = 0.034386931619837524
     gvars[:simulation].EffectStress.RedKsSto = 0
     gvars[:simulation].SCor = 1
-    gvars[:simulation].SWCtopSoilConsidered = true 
+    gvars[:simulation].SWCtopSoilConsidered = true
     gvars[:simulation].DelayedDays = 0
     gvars[:simulation].SumGDD = 2048.0500000000002
     gvars[:simulation].SumGDDfromDay1 = 2048.0500000000002
@@ -2748,7 +2748,7 @@ function checkpoint11()
     gvars[:compartments][2].Smax = 0.020888888877299096
     gvars[:compartments][2].WFactor = 0.22218498638893547
 
-    
+
     gvars[:compartments][3].Theta = 0.23937934823334678
     gvars[:compartments][3].Fluxout = 0
     gvars[:compartments][3].Smax = 0.020222222200698324
@@ -2756,11 +2756,11 @@ function checkpoint11()
 
 
     gvars[:compartments][4].Theta = 0.23982232869387513
-    gvars[:compartments][4].Fluxout = 0 
+    gvars[:compartments][4].Fluxout = 0
     gvars[:compartments][4].Smax = 0.019444444411330752
     gvars[:compartments][4].WFactor = 0
 
-    
+
     gvars[:compartments][5].Theta = 0.28999999999999998
     gvars[:compartments][5].Fluxout =  0
     gvars[:compartments][5].Smax = 0.018555555509196388
@@ -2772,37 +2772,37 @@ function checkpoint11()
     gvars[:compartments][6].Smax = 0.017555555494295227
     gvars[:compartments][6].WFactor = 0
 
-    
+
     gvars[:compartments][7].Theta = 0.29000000000000004
     gvars[:compartments][7].Fluxout = 0
     gvars[:compartments][7].Smax = 0.016444444366627269
     gvars[:compartments][7].WFactor = 0
 
-    
+
     gvars[:compartments][8].Theta = 0.28999999999999998
     gvars[:compartments][8].Fluxout = 0
     gvars[:compartments][8].Smax = 0.015222222126192517
     gvars[:compartments][8].WFactor = 0
 
-    
+
     gvars[:compartments][9].Theta = 0.29
     gvars[:compartments][9].Fluxout = 0
     gvars[:compartments][9].Smax = 0.013888888772990968
     gvars[:compartments][9].WFactor = 0
 
-    
+
     gvars[:compartments][10].Theta = 0.29
     gvars[:compartments][10].Fluxout = 0
     gvars[:compartments][10].Smax = 0.012444444307022625
     gvars[:compartments][10].WFactor = 0
 
-    
+
     gvars[:compartments][11].Theta = 0.29
     gvars[:compartments][11].Fluxout = 0
     gvars[:compartments][11].Smax = 0.010888888728287485
     gvars[:compartments][11].WFactor = 0
 
-    
+
     gvars[:compartments][12].Theta = 0.29
     gvars[:compartments][12].Fluxout = 0
     gvars[:compartments][12].Smax = 0.0092222221361266243
@@ -2811,20 +2811,20 @@ function checkpoint11()
 
     gvars[:total_water_content].BeginDay = 852.41597100717559
     gvars[:total_water_content].EndDay = 855.81417749798811
-    gvars[:total_water_content].ErrorDay = -1.1368683772161603e-13 
-    
+    gvars[:total_water_content].ErrorDay = -1.1368683772161603e-13
+
 
     gvars[:total_salt_content].BeginDay = 0
     gvars[:total_salt_content].EndDay = 0
     gvars[:total_salt_content].ErrorDay = 0
 
-    
+
     gvars[:stresstot].Salt = 0
     gvars[:stresstot].Temp = 10.810686515053268
     gvars[:stresstot].Exp = 0
     gvars[:stresstot].Sto = -6.9414627017820649e-17
     gvars[:stresstot].Weed = 0
-    gvars[:stresstot].NrD = 177 
+    gvars[:stresstot].NrD = 177
 
 
     gvars[:sumwabal].Epot = 324.01814856315099
@@ -2846,34 +2846,34 @@ function checkpoint11()
     gvars[:sumwabal].BiomassTot = 11.947435887342117
     gvars[:sumwabal].SaltIn = 0
     gvars[:sumwabal].SaltOut = 0
-    gvars[:sumwabal].CRsalt = 0 
- 
+    gvars[:sumwabal].CRsalt = 0
+
 
     gvars[:cut_info_record1].NoMoreInfo = false
     gvars[:cut_info_record1].FromDay = 897
 
 
     gvars[:root_zone_wc].Actual = 855.81416453397787
-    gvars[:root_zone_wc].FC = 870 
+    gvars[:root_zone_wc].FC = 870
     gvars[:root_zone_wc].WP = 390
-    gvars[:root_zone_wc].SAT = 1380 
+    gvars[:root_zone_wc].SAT = 1380
     gvars[:root_zone_wc].Leaf = 718.84087924137236
     gvars[:root_zone_wc].Thresh = 526.01021837954056
     gvars[:root_zone_wc].Sen = 485.99831835082034
     gvars[:root_zone_wc].ZtopAct = 32.399041464321684
     gvars[:root_zone_wc].ZtopFC = 29
     gvars[:root_zone_wc].ZtopWP = 13
-    gvars[:root_zone_wc].ZtopThresh = 17.533673945984688 
+    gvars[:root_zone_wc].ZtopThresh = 17.533673945984688
 
 
     gvars[:transfer].Store = true
-    gvars[:transfer].Mobilize = false 
+    gvars[:transfer].Mobilize = false
     gvars[:transfer].ToMobilize = 0.2803701573967029
     gvars[:transfer].Bmobilized = 0.2803701573967029
 
 
     gvars[:plotvarcrop].PotVal = 99.998458084931841
-    gvars[:plotvarcrop].ActVal = 57.993860153952845 
+    gvars[:plotvarcrop].ActVal = 57.993860153952845
 
     popfirst!(gvars[:array_parameters][:Man])
     popfirst!(gvars[:array_parameters][:Man])
@@ -2898,8 +2898,8 @@ function checkpoint12()
 
     AquaCrop.setparameter!(gvars[:float_parameters], :eto, 0.5)
     AquaCrop.setparameter!(gvars[:float_parameters], :rain, 2.7)
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, -0.5) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 6.9) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmin, -0.5)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tmax, 6.9)
     AquaCrop.setparameter!(gvars[:float_parameters], :irrigation, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surfacestorage, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecstorage, 0.0)
@@ -2909,67 +2909,67 @@ function checkpoint12()
     AquaCrop.setparameter!(gvars[:float_parameters], :crwater, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :crsalt, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :eciaqua, AquaCrop.undef_double) #undef_int
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 653.69999999999936) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumeto, 653.69999999999936)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgdd, 2213.1000000000004)
     AquaCrop.setparameter!(gvars[:float_parameters], :previoussumeto, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :previoussumgdd, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :previousbmob, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :previousbmob, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :previousbsto, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.94999999994807116) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :co2i, 404.41000000000003) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :fracbiomasspotsf, 0.50504894020083835) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccxwitheredtpotnos, 0.94999999994807116)
+    AquaCrop.setparameter!(gvars[:float_parameters], :co2i, 404.41000000000003)
+    AquaCrop.setparameter!(gvars[:float_parameters], :fracbiomasspotsf, 0.50504894020083835)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb0, 85.519426917960672)
-    AquaCrop.setparameter!(gvars[:float_parameters], :coeffb1, -0.55385375548550353) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :coeffb1, -0.55385375548550353)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb2, -0.0029584941472780416)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb0salt, 0.84309868976428959)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb1salt, 0.34567807492239472)
     AquaCrop.setparameter!(gvars[:float_parameters], :coeffb2salt, 0.0053253789821134838)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop, 172.5262808649729)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 89.713666049785914) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumkctop_stress, 89.713666049785914)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumkci, 90.331044809451299)
-    AquaCrop.setparameter!(gvars[:float_parameters], :fweednos, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :ccxcrop_weednosf_stress, 0.95) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :fweednos, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :ccxcrop_weednosf_stress, 0.95)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccxtotal, 0.94406250000000003)
     AquaCrop.setparameter!(gvars[:float_parameters], :cdctotal, 0.005)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddcdctotal, 0.006) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddcdctotal, 0.006)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccototal, 0.046047152924789531)
-    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 2103.6999999999998) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :sumgddprev, 2103.6999999999998)
     AquaCrop.setparameter!(gvars[:float_parameters], :gddayi, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :dayfraction, 0.87248322147651003)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddayfraction, 0.90324354040681698) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddayfraction, 0.90324354040681698)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciprev, 0.53428733476014956)
     AquaCrop.setparameter!(gvars[:float_parameters], :cciactual, 0.53428733476014956)
     AquaCrop.setparameter!(gvars[:float_parameters], :timesenescence, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 3.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 3.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :ziprev, 3.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :rooting_depth, 3.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :sumgddcuts, 540.5500000000003)
-    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 11.156816074561055) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :bprevsum, 11.156816074561055)
     AquaCrop.setparameter!(gvars[:float_parameters], :yprevsum, 11.156816074561059)
     AquaCrop.setparameter!(gvars[:float_parameters], :cgcref, 0.12293333333333333)
-    AquaCrop.setparameter!(gvars[:float_parameters], :gddcgcref, 0.012) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :gddcgcref, 0.012)
     AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_bef, AquaCrop.undef_double)
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at1, 1.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at2, 1.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at1, 1.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at2, 1.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :hi_times_at, 1.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi_adj, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi, 100)
+    AquaCrop.setparameter!(gvars[:float_parameters], :alfa_hi_adj, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :scor_at1, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :scor_at2, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, -33.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :stressleaf, -33.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :stresssenescence, AquaCrop.undef_double)
-    AquaCrop.setparameter!(gvars[:float_parameters], :tact, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :tact, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tpot, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bin, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :bout, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :surf0, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ecdrain, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.55) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.55000000000000004) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0) 
-    AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :eact, 0.55)
+    AquaCrop.setparameter!(gvars[:float_parameters], :epot, 0.55000000000000004)
+    AquaCrop.setparameter!(gvars[:float_parameters], :tactweedinfested, 0.0)
+    AquaCrop.setparameter!(gvars[:float_parameters], :saltinfiltr, 0.0)
     AquaCrop.setparameter!(gvars[:float_parameters], :ccitopearlysen, AquaCrop.undef_double)
     AquaCrop.setparameter!(gvars[:float_parameters], :weedrci, 0.0)
-    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.53428733476014956) 
+    AquaCrop.setparameter!(gvars[:float_parameters], :cciactualweedinfested, 0.53428733476014956)
 
 
     AquaCrop.setparameter!(gvars[:integer_parameters], :daylastcut, 115)
@@ -2986,31 +2986,31 @@ function checkpoint12()
     AquaCrop.setparameter!(gvars[:bool_parameters], :startmode, false)
     AquaCrop.setparameter!(gvars[:bool_parameters], :preday, true)
 
-   
+
     gvars[:crop].GDDaysToHarvest = 2104
     gvars[:crop].GDDaysToSenescence = 2104
-    gvars[:crop].GDDaysToFullCanopySF = 572 
-    gvars[:crop].GDDaysToCCini = 171 
-    gvars[:crop].DaysToMaxRooting = 143 
-    gvars[:crop].DaysToHarvest = 175 
-    gvars[:crop].DaysToSenescence = 175 
-    gvars[:crop].DaysToFullCanopySF = 54 
-    gvars[:crop].DaysToFullCanopy = 45 
-    gvars[:crop].DaysToGermination = 2 
-    gvars[:crop].DaysToCCini = 17 
-    gvars[:crop].DaysToHIo = 19 
+    gvars[:crop].GDDaysToFullCanopySF = 572
+    gvars[:crop].GDDaysToCCini = 171
+    gvars[:crop].DaysToMaxRooting = 143
+    gvars[:crop].DaysToHarvest = 175
+    gvars[:crop].DaysToSenescence = 175
+    gvars[:crop].DaysToFullCanopySF = 54
+    gvars[:crop].DaysToFullCanopy = 45
+    gvars[:crop].DaysToGermination = 2
+    gvars[:crop].DaysToCCini = 17
+    gvars[:crop].DaysToHIo = 19
     gvars[:crop].CCxAdjusted = 0.53428733476014956
     gvars[:crop].CCxWithered = 0.53428733476014956
     gvars[:crop].CCoAdjusted = 0.046047152924789531
-    gvars[:crop].CDC = 0.005 
-    gvars[:crop].CGC = 0.12293333333333333 
-    gvars[:crop].RootMin = 3 
-    gvars[:crop].Length = [0, 26, 149, 0] 
+    gvars[:crop].CDC = 0.005
+    gvars[:crop].CGC = 0.12293333333333333
+    gvars[:crop].RootMin = 3
+    gvars[:crop].Length = [0, 26, 149, 0]
     gvars[:crop].Day1 = 42131
     gvars[:crop].DayN = 42305
-    gvars[:crop].pActStom = 0.71929640970268327 
-    gvars[:crop].pLeafAct = 0.31866289934366654 
-    gvars[:crop].pSenAct = 0.80227631033205904 
+    gvars[:crop].pActStom = 0.71929640970268327
+    gvars[:crop].pLeafAct = 0.31866289934366654
+    gvars[:crop].pSenAct = 0.80227631033205904
     gvars[:crop].dHIdt = 5.2631578947368425
     gvars[:crop].Planting = :Regrowth
 
@@ -3025,7 +3025,7 @@ function checkpoint12()
     gvars[:simulation].SumGDD = 2103.7
     gvars[:simulation].SumGDDfromDay1 = 2103.7
     gvars[:simulation].ToDayNr = 42305
-    gvars[:simulation].FromDayNr = 41936 
+    gvars[:simulation].FromDayNr = 41936
     gvars[:simulation].EvapWCsurf = 2.15
     gvars[:simulation].EvapStartStg2 = AquaCrop.undef_int
     gvars[:simulation].EvapZ = 0.15
@@ -3045,7 +3045,7 @@ function checkpoint12()
     gvars[:compartments][2].Smax = 0.020888888877299096
     gvars[:compartments][2].WFactor = 0.22218498638893547
 
-    
+
     gvars[:compartments][3].Theta = 0.29150075618956817
     gvars[:compartments][3].Fluxout = 4.6408439827564409
     gvars[:compartments][3].Smax = 0.020222222200698324
@@ -3054,7 +3054,7 @@ function checkpoint12()
 
     gvars[:compartments][4].Theta = 0.26807589605683513
 
-    
+
     gvars[:compartments][5].Theta = 0.13000000000000014
 
 
@@ -3063,18 +3063,18 @@ function checkpoint12()
 
     gvars[:total_water_content].BeginDay = 804.58949638303898
     gvars[:total_water_content].EndDay = 806.73949638303907
-    gvars[:total_water_content].ErrorDay = 0.0 
+    gvars[:total_water_content].ErrorDay = 0.0
 
 
     gvars[:soil_layers][1].WaterContent = 891.22916344391228
 
 
-    gvars[:stresstot].Salt = 0 
+    gvars[:stresstot].Salt = 0
     gvars[:stresstot].Temp = 11.554330894561998
     gvars[:stresstot].Exp =  1.0549629815117196
     gvars[:stresstot].Sto =  -6.608470384673552e-17
-    gvars[:stresstot].Weed = 0 
-    gvars[:stresstot].NrD = 175 
+    gvars[:stresstot].Weed = 0
+    gvars[:stresstot].NrD = 175
 
 
     gvars[:sumwabal].Epot = 365.15002123473676
@@ -3096,34 +3096,34 @@ function checkpoint12()
     gvars[:sumwabal].BiomassTot = 12.57859510962437
     gvars[:sumwabal].SaltIn = 0
     gvars[:sumwabal].SaltOut = 0
-    gvars[:sumwabal].CRsalt = 0 
+    gvars[:sumwabal].CRsalt = 0
 
 
-    gvars[:cut_info_record1].NoMoreInfo = true 
-    gvars[:cut_info_record1].FromDay = 972 
+    gvars[:cut_info_record1].NoMoreInfo = true
+    gvars[:cut_info_record1].FromDay = 972
 
 
     gvars[:root_zone_wc].Actual = 806.73948341902883
-    gvars[:root_zone_wc].FC = 870 
+    gvars[:root_zone_wc].FC = 870
     gvars[:root_zone_wc].WP = 390
-    gvars[:root_zone_wc].SAT = 1380 
+    gvars[:root_zone_wc].SAT = 1380
     gvars[:root_zone_wc].Leaf = 717.04180831504016
     gvars[:root_zone_wc].Thresh = 524.737723342712
     gvars[:root_zone_wc].Sen = 484.90737104061168
     gvars[:root_zone_wc].ZtopAct = 31.350599913390109
     gvars[:root_zone_wc].ZtopFC = 29
     gvars[:root_zone_wc].ZtopWP = 13
-    gvars[:root_zone_wc].ZtopThresh = 17.491257444757068 
+    gvars[:root_zone_wc].ZtopThresh = 17.491257444757068
 
 
     gvars[:transfer].Store = true
-    gvars[:transfer].Mobilize = false 
+    gvars[:transfer].Mobilize = false
     gvars[:transfer].ToMobilize = 1.3838839288017948
     gvars[:transfer].Bmobilized = 1.3835300268634934
 
 
     gvars[:plotvarcrop].PotVal = 99.999999994533795
-    gvars[:plotvarcrop].ActVal = 56.240772080015745 
+    gvars[:plotvarcrop].ActVal = 56.240772080015745
 
 
     outputs[:tcropsim] = Dict(

--- a/test/filemanagement_tests.jl
+++ b/test/filemanagement_tests.jl
@@ -5,7 +5,7 @@ include("checkpoints.jl")
 
 @testset "Advance one time step" begin
     # break run.f90:FileManagement:7819
-    
+
     kwargs = (runtype = AquaCrop.NormalFileRun(), )
 
     outputs, gvars = checkpoint5()
@@ -68,7 +68,7 @@ end
 
 @testset "Advance 24 time steps" begin
     # break run.f90:FileManagement:7819
-    
+
     kwargs = (runtype = AquaCrop.NormalFileRun(), )
 
     outputs, gvars = checkpoint5()
@@ -138,7 +138,7 @@ end
 
 @testset "Advance 120 time steps" begin
     # break run.f90:FileManagement:7819
-    
+
     kwargs = (runtype = AquaCrop.NormalFileRun(), )
 
     outputs, gvars = checkpoint5()

--- a/test/initialize_runpart1_tests.jl
+++ b/test/initialize_runpart1_tests.jl
@@ -14,7 +14,7 @@ include("checkpoints.jl")
 
     i = 1
     AquaCrop.load_simulation_project!(outputs, gvars, gvars[:projectinput][i]; kwargs...)
-     
+
 
     @test isapprox(gvars[:simulparam], gvars_0[:simulparam])
     @test isapprox(gvars[:soil], gvars_0[:soil])
@@ -49,7 +49,7 @@ end
     gvars = checkpoint2()
 
     outputs_0, gvars_0 = checkpoint4()
-    
+
     i = 1
     # AquaCrop.adjust_compartments!(gvars)
     # gvars[:sumwabal] = AquaCrop.RepSum()

--- a/test/initialsettings_tests.jl
+++ b/test/initialsettings_tests.jl
@@ -56,12 +56,7 @@ end
     @test isapprox(gvars[:simulparam], gvars_0[:simulparam])
     @test isapprox(gvars[:bool_parameters], gvars_0[:bool_parameters])
     @test isequal(length(projectinput),length(projectinput_0))
-    @test isapprox(projectinput[1], projectinput_0[1]) 
-    @test isapprox(projectinput[2], projectinput_0[2]) 
-    @test isapprox(projectinput[3], projectinput_0[3]) 
+    @test isapprox(projectinput[1], projectinput_0[1])
+    @test isapprox(projectinput[2], projectinput_0[2])
+    @test isapprox(projectinput[3], projectinput_0[3])
 end
-
-
-
-
-

--- a/test/other_runs_tests.jl
+++ b/test/other_runs_tests.jl
@@ -5,7 +5,7 @@ include("checkpoints.jl")
 
 @testset "Second run initialize" begin
     # break run.f90:RunSimulation:7846
-    
+
     kwargs = (runtype = AquaCrop.NormalFileRun(), )
 
     outputs, gvars = checkpoint9()
@@ -15,7 +15,7 @@ include("checkpoints.jl")
     i = 2
     AquaCrop.finalize_run1!(outputs, gvars, i; kwargs...)
     AquaCrop.finalize_run2!(outputs, gvars, i; kwargs...)
-    AquaCrop.initialize_run_part1!(outputs, gvars, i; kwargs...) 
+    AquaCrop.initialize_run_part1!(outputs, gvars, i; kwargs...)
     AquaCrop.initialize_climate!(outputs, gvars, i; kwargs...)
     AquaCrop.initialize_run_part2!(outputs, gvars, i; kwargs...)
 
@@ -58,7 +58,7 @@ end
 
 @testset "Second run finalize" begin
     # break run.f90:RunSimulation:7847
-    
+
     kwargs = (runtype = AquaCrop.NormalFileRun(), )
 
     outputs, gvars = checkpoint10()
@@ -99,7 +99,7 @@ end
 
 @testset "Third run finalize" begin
     # break run.f90:RunSimulation:7847
-    
+
     kwargs = (runtype = AquaCrop.NormalFileRun(), )
 
     outputs, gvars = checkpoint11()
@@ -109,7 +109,7 @@ end
     i = 3
     AquaCrop.finalize_run1!(outputs, gvars, i; kwargs...)
     AquaCrop.finalize_run2!(outputs, gvars, i; kwargs...)
-    AquaCrop.initialize_run_part1!(outputs, gvars, i; kwargs...) 
+    AquaCrop.initialize_run_part1!(outputs, gvars, i; kwargs...)
     AquaCrop.initialize_climate!(outputs, gvars, i; kwargs...)
     AquaCrop.initialize_run_part2!(outputs, gvars, i; kwargs...)
     AquaCrop.file_management!(outputs, gvars, i; kwargs...)

--- a/test/readtoml_tests.jl
+++ b/test/readtoml_tests.jl
@@ -12,7 +12,7 @@ include("checkpoints.jl")
     outputs_0, gvars_0 = checkpoint4()
 
 
-    filepaths  = AquaCrop.initialize_the_program(outputs, parentdir; kwargs...) 
+    filepaths  = AquaCrop.initialize_the_program(outputs, parentdir; kwargs...)
     project_filenames = AquaCrop.initialize_project_filenames(outputs, filepaths; kwargs...)
 
     i = 1


### PR DESCRIPTION
This only removes trailing whitespace, no functional changes. This shows the diff without whitespace changes, which should be empty: https://github.com/gabo-di/AquaCrop.jl/pull/39/files?w=1

In my VS Code I have `files.trimTrailingWhitespace` enabled on save. I can of course turn it off for this repository, but probably it is good practice to remove them.
